### PR TITLE
feat: プロダクト品質評価・レビュー API

### DIFF
--- a/backend/src/app.ts
+++ b/backend/src/app.ts
@@ -6,6 +6,7 @@ import { requestLogger } from './middleware/request-logger.js';
 import { errorResponse } from './middleware/error-response.js';
 import { listingsRouter } from './routes/listings.js';
 import { agentsRouter } from './routes/agents.js';
+import { reviewsRouter } from './routes/reviews.js';
 import { notImplementedRouter } from './routes/not-implemented.js';
 import { webhooksRouter } from './routes/webhooks.js';
 
@@ -34,7 +35,7 @@ export function createApp() {
 
   app.route('/api/v1/agents', agentsRouter);
   app.route('/api/v1/purchases', notImplementedRouter);
-  app.route('/api/v1/listings/:id/reviews', notImplementedRouter);
+  app.route('/api/v1/listings/:id/reviews', reviewsRouter);
 
   app.notFound((c) =>
     errorResponse(

--- a/backend/src/routes/reviews.ts
+++ b/backend/src/routes/reviews.ts
@@ -1,0 +1,189 @@
+import { Hono } from 'hono';
+import { z } from 'zod';
+import { pool } from '../db/index.js';
+import { errorResponse } from '../middleware/error-response.js';
+import { recordAuditLog } from '../services/audit-log.js';
+import { enqueueWebhookJobs } from '../services/webhooks.js';
+import { logger } from '../logger.js';
+
+const reviewSchema = z.object({
+  buyer_id: z.string().min(1),
+  rating: z.number().int().min(1).max(5),
+  comment: z.string().max(5000).optional()
+});
+
+export const reviewsRouter = new Hono();
+
+/**
+ * POST /api/v1/listings/:id/reviews
+ * Submit a review for a listing. Each buyer can only review a listing once.
+ * After insertion, the listing's average_rating and review_count are
+ * recalculated. If average_rating < 2.0 and review_count >= 5, the
+ * listing is automatically hidden and a listing.hidden webhook fires.
+ */
+reviewsRouter.post('/', async (c) => {
+  const listingId = c.req.param('id');
+  if (!z.string().uuid().safeParse(listingId).success) {
+    return errorResponse(
+      c, 400, 'invalid_id',
+      'Listing ID must be a valid UUID.',
+      'Provide a valid UUID.'
+    );
+  }
+
+  let body: unknown;
+  try {
+    body = await c.req.json();
+  } catch {
+    return errorResponse(
+      c, 400, 'invalid_json',
+      'Request body must be valid JSON.',
+      'Ensure the request body is valid JSON.'
+    );
+  }
+
+  const parsed = reviewSchema.safeParse(body);
+  if (!parsed.success) {
+    const fields = parsed.error.flatten().fieldErrors;
+    return errorResponse(
+      c, 422, 'validation_error',
+      'Missing or invalid fields in request body.',
+      'Fix the highlighted fields and retry.',
+      { fields }
+    );
+  }
+
+  const { buyer_id, rating, comment } = parsed.data;
+
+  const client = await pool.connect();
+  try {
+    await client.query('BEGIN');
+
+    // Verify listing exists
+    const listingResult = await client.query(
+      'SELECT id, agent_id FROM listings WHERE id = $1',
+      [listingId]
+    );
+    if (listingResult.rowCount === 0) {
+      await client.query('ROLLBACK');
+      return errorResponse(
+        c, 404, 'listing_not_found',
+        'Listing not found.',
+        'Check the listing ID and try again.'
+      );
+    }
+
+    // Insert review
+    const reviewResult = await client.query(
+      `INSERT INTO reviews (id, listing_id, buyer_id, rating, comment)
+       VALUES (gen_random_uuid(), $1, $2, $3, $4)
+       RETURNING *`,
+      [listingId, buyer_id, rating, comment ?? null]
+    );
+    const review = reviewResult.rows[0];
+
+    // Recalculate average_rating and review_count
+    const statsResult = await client.query(
+      `SELECT COUNT(*)::int as review_count, AVG(rating)::numeric(3,2) as average_rating
+       FROM reviews WHERE listing_id = $1`,
+      [listingId]
+    );
+    const { review_count, average_rating } = statsResult.rows[0];
+
+    // Check auto-hide condition
+    const shouldHide = review_count >= 5 && parseFloat(average_rating) < 2.0;
+
+    // Update listing stats
+    await client.query(
+      `UPDATE listings
+       SET average_rating = $1, review_count = $2, is_hidden = $3
+       WHERE id = $4`,
+      [average_rating, review_count, shouldHide, listingId]
+    );
+
+    await recordAuditLog({
+      agentId: listingResult.rows[0].agent_id,
+      action: 'review.created',
+      metadata: { listing_id: listingId, review_id: review.id, rating },
+      client
+    });
+
+    // Fire listing.hidden webhook if auto-hidden
+    if (shouldHide) {
+      const webhookResult = await client.query(
+        `SELECT id, event_type, url FROM webhooks
+         WHERE event_type = $1 AND is_active = true`,
+        ['listing.hidden']
+      );
+      if (webhookResult.rowCount && webhookResult.rowCount > 0) {
+        await enqueueWebhookJobs({
+          event: 'listing.hidden',
+          payload: { listing_id: listingId, average_rating, review_count },
+          webhooks: webhookResult.rows
+        });
+      }
+
+      await recordAuditLog({
+        agentId: listingResult.rows[0].agent_id,
+        action: 'listing.hidden',
+        metadata: { listing_id: listingId, average_rating, review_count },
+        client
+      });
+    }
+
+    await client.query('COMMIT');
+
+    return c.json({
+      ...review,
+      listing_stats: {
+        average_rating: parseFloat(average_rating),
+        review_count,
+        is_hidden: shouldHide
+      }
+    }, 201);
+  } catch (err: unknown) {
+    await client.query('ROLLBACK');
+
+    if (err && typeof err === 'object' && 'code' in err) {
+      const code = (err as { code?: string }).code;
+      if (code === '23505') {
+        return errorResponse(
+          c, 409, 'review_conflict',
+          'You have already reviewed this listing.',
+          'Each buyer can only submit one review per listing.'
+        );
+      }
+    }
+
+    logger.error({ err }, 'Failed to create review');
+    return errorResponse(
+      c, 500, 'review_create_failed',
+      'Failed to create review.',
+      'Retry later or contact support.'
+    );
+  } finally {
+    client.release();
+  }
+});
+
+/**
+ * GET /api/v1/listings/:id/reviews
+ * Retrieve all reviews for a listing.
+ */
+reviewsRouter.get('/', async (c) => {
+  const listingId = c.req.param('id');
+  if (!z.string().uuid().safeParse(listingId).success) {
+    return errorResponse(
+      c, 400, 'invalid_id',
+      'Listing ID must be a valid UUID.',
+      'Provide a valid UUID.'
+    );
+  }
+
+  const result = await pool.query(
+    `SELECT * FROM reviews WHERE listing_id = $1 ORDER BY created_at DESC`,
+    [listingId]
+  );
+
+  return c.json({ data: result.rows, count: result.rowCount });
+});

--- a/backend/tests/reviews.test.ts
+++ b/backend/tests/reviews.test.ts
@@ -1,0 +1,196 @@
+import { beforeAll, beforeEach, afterAll, describe, expect, it } from 'vitest';
+import { app } from '../src/app.js';
+import { pool } from '../src/db/index.js';
+import { v4 as uuidv4 } from 'uuid';
+
+const apiKey = process.env.API_KEY ?? 'test-key';
+
+async function ensureSchema() {
+  const result = await pool.query(
+    "SELECT to_regclass('public.reviews') as reviews"
+  );
+  if (!result.rows[0].reviews) {
+    throw new Error('Database schema is missing. Run migrations before tests.');
+  }
+}
+
+async function truncateAll() {
+  await pool.query(
+    'TRUNCATE TABLE reviews, listings, agents, webhooks, audit_logs RESTART IDENTITY CASCADE'
+  );
+}
+
+/** Helper: insert an agent and return its id */
+async function createAgent(): Promise<string> {
+  const id = uuidv4();
+  await pool.query(
+    `INSERT INTO agents (id, did, owner_id, name, wallet_address, kms_key_id)
+     VALUES ($1, $2, $3, $4, $5, $6)`,
+    [id, `did:ethr:0x${'a'.repeat(40)}`, 'owner-1', 'test-agent', `0x${'a'.repeat(40)}`, 'local:test']
+  );
+  return id;
+}
+
+/** Helper: insert a listing and return its id */
+async function createListing(agentId: string, url?: string): Promise<string> {
+  const id = uuidv4();
+  await pool.query(
+    `INSERT INTO listings (id, agent_id, title, product_url, product_type, price_usdc)
+     VALUES ($1, $2, $3, $4, $5, $6)`,
+    [id, agentId, 'Test Product', url ?? `https://example.com/${id}`, 'web', 10]
+  );
+  return id;
+}
+
+describe('POST /api/v1/listings/:id/reviews', () => {
+  beforeAll(async () => {
+    await ensureSchema();
+  });
+
+  beforeEach(async () => {
+    await truncateAll();
+  });
+
+  afterAll(async () => {
+    await pool.end();
+  });
+
+  it('returns 422 for missing fields', async () => {
+    const agentId = await createAgent();
+    const listingId = await createListing(agentId);
+
+    const res = await app.request(`/api/v1/listings/${listingId}/reviews`, {
+      method: 'POST',
+      headers: { 'content-type': 'application/json', 'x-api-key': apiKey },
+      body: JSON.stringify({})
+    });
+    expect(res.status).toBe(422);
+  });
+
+  it('returns 404 for non-existent listing', async () => {
+    const fakeId = uuidv4();
+    const res = await app.request(`/api/v1/listings/${fakeId}/reviews`, {
+      method: 'POST',
+      headers: { 'content-type': 'application/json', 'x-api-key': apiKey },
+      body: JSON.stringify({ buyer_id: 'buyer-1', rating: 4 })
+    });
+    expect(res.status).toBe(404);
+  });
+
+  it('creates a review and updates listing stats', async () => {
+    const agentId = await createAgent();
+    const listingId = await createListing(agentId);
+
+    const res = await app.request(`/api/v1/listings/${listingId}/reviews`, {
+      method: 'POST',
+      headers: { 'content-type': 'application/json', 'x-api-key': apiKey },
+      body: JSON.stringify({ buyer_id: 'buyer-1', rating: 4, comment: 'Great product!' })
+    });
+    expect(res.status).toBe(201);
+    const body: any = await res.json();
+    expect(body.rating).toBe(4);
+    expect(body.listing_stats.average_rating).toBe(4.0);
+    expect(body.listing_stats.review_count).toBe(1);
+    expect(body.listing_stats.is_hidden).toBe(false);
+
+    // Verify listing updated
+    const listing = await pool.query('SELECT * FROM listings WHERE id = $1', [listingId]);
+    expect(parseFloat(listing.rows[0].average_rating)).toBe(4.0);
+    expect(listing.rows[0].review_count).toBe(1);
+  });
+
+  it('returns 409 for duplicate review from same buyer', async () => {
+    const agentId = await createAgent();
+    const listingId = await createListing(agentId);
+
+    await app.request(`/api/v1/listings/${listingId}/reviews`, {
+      method: 'POST',
+      headers: { 'content-type': 'application/json', 'x-api-key': apiKey },
+      body: JSON.stringify({ buyer_id: 'buyer-1', rating: 4 })
+    });
+
+    const res = await app.request(`/api/v1/listings/${listingId}/reviews`, {
+      method: 'POST',
+      headers: { 'content-type': 'application/json', 'x-api-key': apiKey },
+      body: JSON.stringify({ buyer_id: 'buyer-1', rating: 3 })
+    });
+    expect(res.status).toBe(409);
+  });
+
+  it('auto-hides listing when avg rating < 2.0 and 5+ reviews', async () => {
+    const agentId = await createAgent();
+    const listingId = await createListing(agentId);
+
+    // Submit 5 reviews with low ratings (all 1 star)
+    for (let i = 0; i < 5; i++) {
+      const res = await app.request(`/api/v1/listings/${listingId}/reviews`, {
+        method: 'POST',
+        headers: { 'content-type': 'application/json', 'x-api-key': apiKey },
+        body: JSON.stringify({ buyer_id: `buyer-${i}`, rating: 1 })
+      });
+      expect(res.status).toBe(201);
+    }
+
+    // Verify listing is hidden
+    const listing = await pool.query('SELECT * FROM listings WHERE id = $1', [listingId]);
+    expect(listing.rows[0].is_hidden).toBe(true);
+    expect(parseFloat(listing.rows[0].average_rating)).toBe(1.0);
+    expect(listing.rows[0].review_count).toBe(5);
+  });
+
+  it('does not auto-hide when avg rating >= 2.0', async () => {
+    const agentId = await createAgent();
+    const listingId = await createListing(agentId);
+
+    // Submit 5 reviews: mix of ratings averaging >= 2.0
+    const ratings = [2, 2, 3, 2, 3]; // avg = 2.4
+    for (let i = 0; i < 5; i++) {
+      await app.request(`/api/v1/listings/${listingId}/reviews`, {
+        method: 'POST',
+        headers: { 'content-type': 'application/json', 'x-api-key': apiKey },
+        body: JSON.stringify({ buyer_id: `buyer-${i}`, rating: ratings[i] })
+      });
+    }
+
+    const listing = await pool.query('SELECT * FROM listings WHERE id = $1', [listingId]);
+    expect(listing.rows[0].is_hidden).toBe(false);
+  });
+});
+
+describe('GET /api/v1/listings/:id/reviews', () => {
+  beforeEach(async () => {
+    await truncateAll();
+  });
+
+  it('returns empty array for listing with no reviews', async () => {
+    const agentId = await createAgent();
+    const listingId = await createListing(agentId);
+
+    const res = await app.request(`/api/v1/listings/${listingId}/reviews`, {
+      headers: { 'x-api-key': apiKey }
+    });
+    expect(res.status).toBe(200);
+    const body: any = await res.json();
+    expect(body.data).toEqual([]);
+    expect(body.count).toBe(0);
+  });
+
+  it('returns reviews for a listing', async () => {
+    const agentId = await createAgent();
+    const listingId = await createListing(agentId);
+
+    await app.request(`/api/v1/listings/${listingId}/reviews`, {
+      method: 'POST',
+      headers: { 'content-type': 'application/json', 'x-api-key': apiKey },
+      body: JSON.stringify({ buyer_id: 'buyer-1', rating: 5, comment: 'Excellent' })
+    });
+
+    const res = await app.request(`/api/v1/listings/${listingId}/reviews`, {
+      headers: { 'x-api-key': apiKey }
+    });
+    expect(res.status).toBe(200);
+    const body: any = await res.json();
+    expect(body.data.length).toBe(1);
+    expect(body.data[0].rating).toBe(5);
+  });
+});


### PR DESCRIPTION
## Summary
- POST `/api/v1/listings/:id/reviews`: 評価(1-5)とレビューテキストをDBに保存
- GET `/api/v1/listings/:id/reviews`: レビュー一覧取得
- レビュー投稿時にlistingsの `average_rating` / `review_count` を自動再計算
- 平均評価 < 2.0 かつ review_count >= 5 で `is_hidden=true` を自動設定
- `listing.hidden` webhookイベント発火
- 同一buyer_idによる重複レビュー防止 (409 Conflict)

## Test plan
- [ ] `npm run test -- tests/reviews.test.ts`
- [ ] レビュー投稿で201返却、listing statsが更新されること
- [ ] 低評価5件で自動非表示になること
- [ ] 同一buyerの重複投稿で409返却

Closes #3

🤖 Generated with [Claude Code](https://claude.com/claude-code)