### PR TITLE
feat: add React + Vite frontend UI

### DIFF
--- a/frontend/.gitignore
+++ b/frontend/.gitignore
@@ -1,0 +1,2 @@
+node_modules
+dist

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -1,0 +1,12 @@
+<!doctype html>
+<html lang="ja">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>OpenClaw Marketplace</title>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/src/main.tsx"></script>
+  </body>
+</html>

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,0 +1,23 @@
+{
+  "name": "openclaw-marketplace-frontend",
+  "private": true,
+  "version": "0.1.0",
+  "type": "module",
+  "scripts": {
+    "dev": "vite",
+    "build": "tsc -b && vite build",
+    "preview": "vite preview"
+  },
+  "dependencies": {
+    "react": "^19.0.0",
+    "react-dom": "^19.0.0",
+    "react-router-dom": "^7.1.0"
+  },
+  "devDependencies": {
+    "@types/react": "^19.0.0",
+    "@types/react-dom": "^19.0.0",
+    "@vitejs/plugin-react": "^4.3.4",
+    "typescript": "^5.6.2",
+    "vite": "^6.0.0"
+  }
+}

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,0 +1,24 @@
+import { Routes, Route, Link } from 'react-router-dom';
+import { CatalogPage } from './pages/CatalogPage';
+import { ListingDetailPage } from './pages/ListingDetailPage';
+import { AgentDashboardPage } from './pages/AgentDashboardPage';
+
+export function App() {
+  return (
+    <div className="app">
+      <header className="header">
+        <Link to="/" className="logo">OpenClaw Marketplace</Link>
+        <nav>
+          <Link to="/">Catalog</Link>
+        </nav>
+      </header>
+      <main className="main">
+        <Routes>
+          <Route path="/" element={<CatalogPage />} />
+          <Route path="/listings/:id" element={<ListingDetailPage />} />
+          <Route path="/agents/:id" element={<AgentDashboardPage />} />
+        </Routes>
+      </main>
+    </div>
+  );
+}

--- a/frontend/src/api.ts
+++ b/frontend/src/api.ts
@@ -1,0 +1,127 @@
+const API_KEY = import.meta.env.VITE_API_KEY || 'dev-api-key';
+
+async function apiFetch<T>(path: string, init?: RequestInit): Promise<T> {
+  const res = await fetch(path, {
+    ...init,
+    headers: {
+      'Content-Type': 'application/json',
+      'x-api-key': API_KEY,
+      ...init?.headers
+    }
+  });
+  if (!res.ok) {
+    const body = await res.json().catch(() => ({}));
+    throw new Error(body.message || `API error ${res.status}`);
+  }
+  return res.json();
+}
+
+export type Listing = {
+  id: string;
+  agent_id: string;
+  title: string;
+  description: string | null;
+  product_url: string;
+  product_type: string;
+  price_usdc: number;
+  average_rating: number;
+  review_count: number;
+  is_hidden: boolean;
+  moltbook_id: string | null;
+  status: string;
+  created_at: string;
+};
+
+export type Agent = {
+  id: string;
+  did: string;
+  owner_id: string;
+  name: string;
+  wallet_address: string;
+  kms_key_id: string;
+  created_at: string;
+};
+
+export type WalletBalance = {
+  agent_id: string;
+  wallet_address: string;
+  balance_wei: string;
+  balance_eth: string;
+  balance_usdc: string | null;
+};
+
+export type Review = {
+  id: string;
+  listing_id: string;
+  buyer_id: string;
+  rating: number;
+  comment: string | null;
+  created_at: string;
+};
+
+export type Purchase = {
+  id: string;
+  listing_id: string;
+  buyer_wallet: string;
+  seller_agent_id: string;
+  amount_usdc: number;
+  tx_hash: string | null;
+  status: string;
+  idempotency_key: string;
+  created_at: string;
+};
+
+export type ListingsResponse = {
+  data: Listing[];
+  pagination: { limit: number; offset: number; count: number };
+};
+
+export const api = {
+  listListings(params?: {
+    agent_id?: string;
+    product_type?: string;
+    status?: string;
+    is_hidden?: string;
+    limit?: number;
+    offset?: number;
+  }): Promise<ListingsResponse> {
+    const query = new URLSearchParams();
+    if (params) {
+      for (const [k, v] of Object.entries(params)) {
+        if (v !== undefined) query.set(k, String(v));
+      }
+    }
+    const qs = query.toString();
+    return apiFetch(`/api/v1/listings${qs ? `?${qs}` : ''}`);
+  },
+
+  getListing(id: string): Promise<Listing> {
+    return apiFetch(`/api/v1/listings/${id}`);
+  },
+
+  getAgent(id: string): Promise<Agent> {
+    return apiFetch(`/api/v1/agents/${id}`);
+  },
+
+  getWalletBalance(agentId: string): Promise<WalletBalance> {
+    return apiFetch(`/api/v1/agents/${agentId}/wallet`);
+  },
+
+  getReviews(listingId: string): Promise<Review[]> {
+    return apiFetch(`/api/v1/listings/${listingId}/reviews`);
+  },
+
+  submitReview(listingId: string, data: { buyer_id: string; rating: number; comment?: string }): Promise<unknown> {
+    return apiFetch(`/api/v1/listings/${listingId}/reviews`, {
+      method: 'POST',
+      body: JSON.stringify(data)
+    });
+  },
+
+  purchase(data: { listing_id: string; buyer_wallet: string; idempotency_key: string }): Promise<Purchase> {
+    return apiFetch('/api/v1/purchases', {
+      method: 'POST',
+      body: JSON.stringify(data)
+    });
+  }
+};

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -1,0 +1,262 @@
+*,
+*::before,
+*::after {
+  box-sizing: border-box;
+  margin: 0;
+  padding: 0;
+}
+
+body {
+  font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
+  background: #f5f5f7;
+  color: #1d1d1f;
+  line-height: 1.5;
+}
+
+a {
+  color: #0066cc;
+  text-decoration: none;
+}
+a:hover {
+  text-decoration: underline;
+}
+
+.header {
+  display: flex;
+  align-items: center;
+  gap: 2rem;
+  padding: 1rem 2rem;
+  background: #fff;
+  border-bottom: 1px solid #e0e0e0;
+  position: sticky;
+  top: 0;
+  z-index: 10;
+}
+
+.logo {
+  font-size: 1.25rem;
+  font-weight: 700;
+  color: #1d1d1f;
+}
+
+.main {
+  max-width: 1200px;
+  margin: 0 auto;
+  padding: 2rem;
+}
+
+.card {
+  background: #fff;
+  border-radius: 12px;
+  padding: 1.5rem;
+  box-shadow: 0 1px 3px rgba(0, 0, 0, 0.08);
+}
+
+.card + .card {
+  margin-top: 1rem;
+}
+
+.grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(300px, 1fr));
+  gap: 1.25rem;
+}
+
+.badge {
+  display: inline-block;
+  padding: 0.15rem 0.5rem;
+  border-radius: 4px;
+  font-size: 0.75rem;
+  font-weight: 600;
+}
+
+.badge-active {
+  background: #e8f5e9;
+  color: #2e7d32;
+}
+
+.badge-hidden {
+  background: #fce4ec;
+  color: #c62828;
+}
+
+.stars {
+  color: #f9a825;
+  font-size: 0.9rem;
+}
+
+.price {
+  font-size: 1.25rem;
+  font-weight: 700;
+  color: #1d1d1f;
+}
+
+.btn {
+  display: inline-block;
+  padding: 0.5rem 1.25rem;
+  border: none;
+  border-radius: 8px;
+  font-size: 0.9rem;
+  font-weight: 600;
+  cursor: pointer;
+  transition: opacity 0.15s;
+}
+.btn:hover {
+  opacity: 0.85;
+}
+.btn:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+
+.btn-primary {
+  background: #0066cc;
+  color: #fff;
+}
+
+.btn-secondary {
+  background: #e0e0e0;
+  color: #1d1d1f;
+}
+
+.filters {
+  display: flex;
+  gap: 1rem;
+  margin-bottom: 1.5rem;
+  flex-wrap: wrap;
+  align-items: center;
+}
+
+.filters select,
+.filters input {
+  padding: 0.4rem 0.75rem;
+  border: 1px solid #ccc;
+  border-radius: 6px;
+  font-size: 0.875rem;
+}
+
+.section-title {
+  font-size: 1.25rem;
+  font-weight: 700;
+  margin-bottom: 1rem;
+}
+
+.stat-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(200px, 1fr));
+  gap: 1rem;
+  margin-bottom: 1.5rem;
+}
+
+.stat-card {
+  background: #fff;
+  border-radius: 12px;
+  padding: 1.25rem;
+  box-shadow: 0 1px 3px rgba(0, 0, 0, 0.08);
+  text-align: center;
+}
+
+.stat-value {
+  font-size: 1.5rem;
+  font-weight: 700;
+}
+
+.stat-label {
+  font-size: 0.8rem;
+  color: #666;
+  margin-top: 0.25rem;
+}
+
+.review-item {
+  padding: 1rem 0;
+  border-bottom: 1px solid #eee;
+}
+
+.review-item:last-child {
+  border-bottom: none;
+}
+
+.review-meta {
+  font-size: 0.8rem;
+  color: #666;
+  margin-top: 0.25rem;
+}
+
+.empty {
+  text-align: center;
+  padding: 3rem;
+  color: #999;
+}
+
+.error {
+  text-align: center;
+  padding: 2rem;
+  color: #c62828;
+}
+
+.loading {
+  text-align: center;
+  padding: 2rem;
+  color: #666;
+}
+
+.detail-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: flex-start;
+  gap: 2rem;
+  margin-bottom: 1.5rem;
+}
+
+.detail-info {
+  flex: 1;
+}
+
+.detail-aside {
+  min-width: 200px;
+  text-align: right;
+}
+
+.form-group {
+  margin-bottom: 1rem;
+}
+
+.form-group label {
+  display: block;
+  font-size: 0.875rem;
+  font-weight: 600;
+  margin-bottom: 0.25rem;
+}
+
+.form-group input,
+.form-group select,
+.form-group textarea {
+  width: 100%;
+  padding: 0.5rem;
+  border: 1px solid #ccc;
+  border-radius: 6px;
+  font-size: 0.875rem;
+}
+
+.form-group textarea {
+  resize: vertical;
+  min-height: 80px;
+}
+
+.wallet-address {
+  font-family: monospace;
+  font-size: 0.85rem;
+  word-break: break-all;
+}
+
+.listing-row {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: 0.75rem 0;
+  border-bottom: 1px solid #eee;
+}
+
+.listing-row:last-child {
+  border-bottom: none;
+}

--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -1,0 +1,13 @@
+import { StrictMode } from 'react';
+import { createRoot } from 'react-dom/client';
+import { BrowserRouter } from 'react-router-dom';
+import { App } from './App';
+import './index.css';
+
+createRoot(document.getElementById('root')!).render(
+  <StrictMode>
+    <BrowserRouter>
+      <App />
+    </BrowserRouter>
+  </StrictMode>
+);

--- a/frontend/src/pages/AgentDashboardPage.tsx
+++ b/frontend/src/pages/AgentDashboardPage.tsx
@@ -1,0 +1,113 @@
+import { useEffect, useState } from 'react';
+import { useParams, Link } from 'react-router-dom';
+import { api, type Agent, type WalletBalance, type Listing } from '../api';
+
+export function AgentDashboardPage() {
+  const { id } = useParams<{ id: string }>();
+  const [agent, setAgent] = useState<Agent | null>(null);
+  const [wallet, setWallet] = useState<WalletBalance | null>(null);
+  const [listings, setListings] = useState<Listing[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (!id) return;
+    setLoading(true);
+    setError(null);
+
+    Promise.all([
+      api.getAgent(id),
+      api.getWalletBalance(id).catch(() => null),
+      api.listListings({ agent_id: id, limit: 100 })
+    ])
+      .then(([a, w, l]) => {
+        setAgent(a);
+        setWallet(w);
+        setListings(l.data);
+      })
+      .catch((err) => setError(err.message))
+      .finally(() => setLoading(false));
+  }, [id]);
+
+  if (loading) return <div className="loading">Loading agent...</div>;
+  if (error) return <div className="error">{error}</div>;
+  if (!agent) return <div className="empty">Agent not found.</div>;
+
+  const totalRevenue = listings.reduce((sum, l) => sum + Number(l.price_usdc) * l.review_count, 0);
+
+  return (
+    <div>
+      <div style={{ marginBottom: '1rem' }}>
+        <Link to="/">&larr; Back to Catalog</Link>
+      </div>
+
+      <div className="card" style={{ marginBottom: '1.5rem' }}>
+        <h1 style={{ fontSize: '1.5rem', marginBottom: '0.5rem' }}>{agent.name}</h1>
+        <p style={{ fontSize: '0.85rem', color: '#666', marginBottom: '0.25rem' }}>
+          DID: <span className="wallet-address">{agent.did}</span>
+        </p>
+        <p style={{ fontSize: '0.85rem', color: '#666', marginBottom: '0.25rem' }}>
+          Owner: {agent.owner_id}
+        </p>
+        <p style={{ fontSize: '0.85rem', color: '#666' }}>
+          Registered: {new Date(agent.created_at).toLocaleDateString()}
+        </p>
+      </div>
+
+      <h2 className="section-title">Wallet</h2>
+      <div className="stat-grid">
+        <div className="stat-card">
+          <div className="stat-value">{wallet ? wallet.balance_eth : '—'}</div>
+          <div className="stat-label">ETH Balance</div>
+        </div>
+        <div className="stat-card">
+          <div className="stat-value">{wallet?.balance_usdc ?? '—'}</div>
+          <div className="stat-label">USDC Balance</div>
+        </div>
+        <div className="stat-card">
+          <div className="stat-value">{listings.length}</div>
+          <div className="stat-label">Active Listings</div>
+        </div>
+        <div className="stat-card">
+          <div className="stat-value">${totalRevenue.toFixed(2)}</div>
+          <div className="stat-label">Est. Revenue (USDC)</div>
+        </div>
+      </div>
+
+      {wallet && (
+        <div className="card" style={{ marginBottom: '1.5rem' }}>
+          <h3 style={{ fontSize: '0.9rem', marginBottom: '0.5rem' }}>Wallet Address</h3>
+          <p className="wallet-address">{wallet.wallet_address}</p>
+        </div>
+      )}
+
+      <h2 className="section-title">Listings</h2>
+      {listings.length === 0 ? (
+        <div className="empty">No listings yet.</div>
+      ) : (
+        <div className="card">
+          {listings.map((listing) => (
+            <div key={listing.id} className="listing-row">
+              <div>
+                <Link to={`/listings/${listing.id}`} style={{ fontWeight: 600 }}>
+                  {listing.title}
+                </Link>
+                <div style={{ fontSize: '0.8rem', color: '#666' }}>
+                  {listing.product_type} &middot;{' '}
+                  <span className="stars">{'★'.repeat(Math.floor(Number(listing.average_rating)))}</span>
+                  {' '}({listing.review_count} reviews)
+                </div>
+              </div>
+              <div style={{ textAlign: 'right' }}>
+                <div className="price">${Number(listing.price_usdc).toFixed(2)}</div>
+                <span className={`badge ${listing.is_hidden ? 'badge-hidden' : 'badge-active'}`}>
+                  {listing.is_hidden ? 'Hidden' : listing.status}
+                </span>
+              </div>
+            </div>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/frontend/src/pages/CatalogPage.tsx
+++ b/frontend/src/pages/CatalogPage.tsx
@@ -1,0 +1,91 @@
+import { useEffect, useState } from 'react';
+import { Link } from 'react-router-dom';
+import { api, type Listing } from '../api';
+
+function StarRating({ rating }: { rating: number }) {
+  const full = Math.floor(rating);
+  const half = rating - full >= 0.5;
+  const stars = '★'.repeat(full) + (half ? '½' : '') + '☆'.repeat(5 - full - (half ? 1 : 0));
+  return <span className="stars">{stars} ({rating.toFixed(1)})</span>;
+}
+
+export function CatalogPage() {
+  const [listings, setListings] = useState<Listing[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [productType, setProductType] = useState('');
+  const [showHidden, setShowHidden] = useState(false);
+
+  useEffect(() => {
+    setLoading(true);
+    setError(null);
+    const params: Record<string, string | number> = { limit: 50, offset: 0 };
+    if (productType) params.product_type = productType;
+    if (!showHidden) params.is_hidden = 'false';
+
+    api.listListings(params)
+      .then((res) => setListings(res.data))
+      .catch((err) => setError(err.message))
+      .finally(() => setLoading(false));
+  }, [productType, showHidden]);
+
+  return (
+    <div>
+      <h1 className="section-title">Catalog</h1>
+
+      <div className="filters">
+        <select value={productType} onChange={(e) => setProductType(e.target.value)}>
+          <option value="">All Types</option>
+          <option value="web">Web</option>
+          <option value="api">API</option>
+          <option value="cli">CLI</option>
+          <option value="mobile">Mobile</option>
+          <option value="library">Library</option>
+        </select>
+
+        <label style={{ display: 'flex', alignItems: 'center', gap: '0.4rem', fontSize: '0.875rem' }}>
+          <input
+            type="checkbox"
+            checked={showHidden}
+            onChange={(e) => setShowHidden(e.target.checked)}
+          />
+          Show hidden
+        </label>
+      </div>
+
+      {loading && <div className="loading">Loading listings...</div>}
+      {error && <div className="error">{error}</div>}
+      {!loading && !error && listings.length === 0 && (
+        <div className="empty">No listings found.</div>
+      )}
+
+      <div className="grid">
+        {listings.map((listing) => (
+          <Link key={listing.id} to={`/listings/${listing.id}`} style={{ textDecoration: 'none', color: 'inherit' }}>
+            <div className="card" style={{ cursor: 'pointer' }}>
+              <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', marginBottom: '0.5rem' }}>
+                <span className={`badge ${listing.is_hidden ? 'badge-hidden' : 'badge-active'}`}>
+                  {listing.is_hidden ? 'Hidden' : listing.status}
+                </span>
+                <span style={{ fontSize: '0.75rem', color: '#999' }}>{listing.product_type}</span>
+              </div>
+              <h3 style={{ fontSize: '1rem', marginBottom: '0.5rem' }}>{listing.title}</h3>
+              {listing.description && (
+                <p style={{ fontSize: '0.85rem', color: '#666', marginBottom: '0.75rem', overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>
+                  {listing.description}
+                </p>
+              )}
+              <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center' }}>
+                <span className="price">${Number(listing.price_usdc).toFixed(2)}</span>
+                <StarRating rating={Number(listing.average_rating)} />
+              </div>
+              <div style={{ fontSize: '0.75rem', color: '#999', marginTop: '0.5rem' }}>
+                {listing.review_count} review{listing.review_count !== 1 ? 's' : ''}
+              </div>
+            </div>
+          </Link>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/pages/ListingDetailPage.tsx
+++ b/frontend/src/pages/ListingDetailPage.tsx
@@ -1,0 +1,203 @@
+import { useEffect, useState } from 'react';
+import { useParams, Link } from 'react-router-dom';
+import { api, type Listing, type Review } from '../api';
+
+function StarRating({ rating }: { rating: number }) {
+  const full = Math.floor(rating);
+  const half = rating - full >= 0.5;
+  const stars = '★'.repeat(full) + (half ? '½' : '') + '☆'.repeat(5 - full - (half ? 1 : 0));
+  return <span className="stars">{stars} ({rating.toFixed(1)})</span>;
+}
+
+export function ListingDetailPage() {
+  const { id } = useParams<{ id: string }>();
+  const [listing, setListing] = useState<Listing | null>(null);
+  const [reviews, setReviews] = useState<Review[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  const [buyerWallet, setBuyerWallet] = useState('');
+  const [purchasing, setPurchasing] = useState(false);
+  const [purchaseResult, setPurchaseResult] = useState<string | null>(null);
+
+  const [reviewBuyerId, setReviewBuyerId] = useState('');
+  const [reviewRating, setReviewRating] = useState(5);
+  const [reviewComment, setReviewComment] = useState('');
+  const [submittingReview, setSubmittingReview] = useState(false);
+
+  useEffect(() => {
+    if (!id) return;
+    setLoading(true);
+    Promise.all([api.getListing(id), api.getReviews(id)])
+      .then(([l, r]) => {
+        setListing(l);
+        setReviews(Array.isArray(r) ? r : []);
+      })
+      .catch((err) => setError(err.message))
+      .finally(() => setLoading(false));
+  }, [id]);
+
+  async function handlePurchase() {
+    if (!listing || !buyerWallet) return;
+    setPurchasing(true);
+    setPurchaseResult(null);
+    try {
+      const result = await api.purchase({
+        listing_id: listing.id,
+        buyer_wallet: buyerWallet,
+        idempotency_key: `purchase-${listing.id}-${Date.now()}`
+      });
+      setPurchaseResult(`Purchase completed! tx: ${result.tx_hash || 'pending'}`);
+    } catch (err: unknown) {
+      setPurchaseResult(`Purchase failed: ${err instanceof Error ? err.message : String(err)}`);
+    } finally {
+      setPurchasing(false);
+    }
+  }
+
+  async function handleReviewSubmit(e: React.FormEvent) {
+    e.preventDefault();
+    if (!id || !reviewBuyerId) return;
+    setSubmittingReview(true);
+    try {
+      await api.submitReview(id, {
+        buyer_id: reviewBuyerId,
+        rating: reviewRating,
+        comment: reviewComment || undefined
+      });
+      const updated = await api.getReviews(id);
+      setReviews(Array.isArray(updated) ? updated : []);
+      const updatedListing = await api.getListing(id);
+      setListing(updatedListing);
+      setReviewBuyerId('');
+      setReviewComment('');
+      setReviewRating(5);
+    } catch (err: unknown) {
+      alert(err instanceof Error ? err.message : String(err));
+    } finally {
+      setSubmittingReview(false);
+    }
+  }
+
+  if (loading) return <div className="loading">Loading...</div>;
+  if (error) return <div className="error">{error}</div>;
+  if (!listing) return <div className="empty">Listing not found.</div>;
+
+  return (
+    <div>
+      <div style={{ marginBottom: '1rem' }}>
+        <Link to="/">&larr; Back to Catalog</Link>
+      </div>
+
+      <div className="card">
+        <div className="detail-header">
+          <div className="detail-info">
+            <h1 style={{ fontSize: '1.5rem', marginBottom: '0.5rem' }}>{listing.title}</h1>
+            <div style={{ display: 'flex', gap: '1rem', alignItems: 'center', marginBottom: '0.75rem' }}>
+              <span className={`badge ${listing.is_hidden ? 'badge-hidden' : 'badge-active'}`}>
+                {listing.is_hidden ? 'Hidden' : listing.status}
+              </span>
+              <span style={{ fontSize: '0.85rem', color: '#666' }}>{listing.product_type}</span>
+              <StarRating rating={Number(listing.average_rating)} />
+              <span style={{ fontSize: '0.85rem', color: '#666' }}>
+                {listing.review_count} review{listing.review_count !== 1 ? 's' : ''}
+              </span>
+            </div>
+            {listing.description && (
+              <p style={{ color: '#444', marginBottom: '1rem' }}>{listing.description}</p>
+            )}
+            <p style={{ fontSize: '0.85rem' }}>
+              Product: <a href={listing.product_url} target="_blank" rel="noreferrer">{listing.product_url}</a>
+            </p>
+            <p style={{ fontSize: '0.85rem' }}>
+              Agent: <Link to={`/agents/${listing.agent_id}`}>{listing.agent_id}</Link>
+            </p>
+          </div>
+          <div className="detail-aside">
+            <div className="price" style={{ fontSize: '1.75rem', marginBottom: '1rem' }}>
+              ${Number(listing.price_usdc).toFixed(2)} USDC
+            </div>
+            <div className="form-group">
+              <input
+                type="text"
+                placeholder="Your wallet address (0x...)"
+                value={buyerWallet}
+                onChange={(e) => setBuyerWallet(e.target.value)}
+              />
+            </div>
+            <button
+              className="btn btn-primary"
+              style={{ width: '100%' }}
+              onClick={handlePurchase}
+              disabled={purchasing || !buyerWallet}
+            >
+              {purchasing ? 'Processing...' : 'Buy Now'}
+            </button>
+            {purchaseResult && (
+              <p style={{ fontSize: '0.8rem', marginTop: '0.5rem', color: purchaseResult.includes('failed') ? '#c62828' : '#2e7d32' }}>
+                {purchaseResult}
+              </p>
+            )}
+          </div>
+        </div>
+      </div>
+
+      <div style={{ marginTop: '2rem' }}>
+        <h2 className="section-title">Reviews</h2>
+
+        <div className="card" style={{ marginBottom: '1.5rem' }}>
+          <h3 style={{ fontSize: '1rem', marginBottom: '0.75rem' }}>Write a Review</h3>
+          <form onSubmit={handleReviewSubmit}>
+            <div className="form-group">
+              <label>Buyer ID</label>
+              <input
+                type="text"
+                value={reviewBuyerId}
+                onChange={(e) => setReviewBuyerId(e.target.value)}
+                placeholder="your-buyer-id"
+                required
+              />
+            </div>
+            <div className="form-group">
+              <label>Rating</label>
+              <select value={reviewRating} onChange={(e) => setReviewRating(Number(e.target.value))}>
+                {[5, 4, 3, 2, 1].map((n) => (
+                  <option key={n} value={n}>{'★'.repeat(n)}{'☆'.repeat(5 - n)} ({n})</option>
+                ))}
+              </select>
+            </div>
+            <div className="form-group">
+              <label>Comment (optional)</label>
+              <textarea
+                value={reviewComment}
+                onChange={(e) => setReviewComment(e.target.value)}
+                placeholder="Your thoughts on this product..."
+              />
+            </div>
+            <button className="btn btn-primary" type="submit" disabled={submittingReview || !reviewBuyerId}>
+              {submittingReview ? 'Submitting...' : 'Submit Review'}
+            </button>
+          </form>
+        </div>
+
+        {reviews.length === 0 ? (
+          <div className="empty">No reviews yet.</div>
+        ) : (
+          <div className="card">
+            {reviews.map((review) => (
+              <div key={review.id} className="review-item">
+                <div>
+                  <span className="stars">{'★'.repeat(review.rating)}{'☆'.repeat(5 - review.rating)}</span>
+                </div>
+                {review.comment && <p style={{ margin: '0.25rem 0' }}>{review.comment}</p>}
+                <div className="review-meta">
+                  by {review.buyer_id} &middot; {new Date(review.created_at).toLocaleDateString()}
+                </div>
+              </div>
+            ))}
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/vite-env.d.ts
+++ b/frontend/src/vite-env.d.ts
@@ -1,0 +1,1 @@
+/// <reference types="vite/client" />

--- a/frontend/tsconfig.json
+++ b/frontend/tsconfig.json
@@ -1,0 +1,21 @@
+{
+  "compilerOptions": {
+    "target": "ES2020",
+    "useDefineForClassFields": true,
+    "lib": ["ES2020", "DOM", "DOM.Iterable"],
+    "module": "ESNext",
+    "skipLibCheck": true,
+    "moduleResolution": "bundler",
+    "allowImportingTsExtensions": true,
+    "isolatedModules": true,
+    "moduleDetection": "force",
+    "noEmit": true,
+    "jsx": "react-jsx",
+    "strict": true,
+    "noUnusedLocals": true,
+    "noUnusedParameters": true,
+    "noFallthroughCasesInSwitch": true,
+    "noUncheckedSideEffectImports": true
+  },
+  "include": ["src"]
+}

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -1,0 +1,19 @@
+import { defineConfig } from 'vite';
+import react from '@vitejs/plugin-react';
+
+export default defineConfig({
+  plugins: [react()],
+  server: {
+    port: 5173,
+    proxy: {
+      '/api': {
+        target: 'http://localhost:3000',
+        changeOrigin: true
+      },
+      '/health': {
+        target: 'http://localhost:3000',
+        changeOrigin: true
+      }
+    }
+  }
+});


### PR DESCRIPTION
## Summary
- Add React 19 + Vite 6 + TypeScript frontend in `frontend/` directory
- **`/`** - Catalog page with product type filter, hidden listings toggle, star ratings, grid layout
- **`/listings/:id`** - Product detail page with reviews list, review submission form, USDC purchase button
- **`/agents/:id`** - Agent dashboard with ETH/USDC wallet balance, listing management, estimated revenue
- API client (`api.ts`) with typed fetch wrapper connecting to backend via Vite proxy
- Clean CSS with card-based design, responsive grid, sticky header

## Tech Stack
- React 19, React Router 7, TypeScript 5.6, Vite 6
- Vite dev proxy: `/api` -> `http://localhost:3000`

## How to Run
```bash
cd frontend
npm install
npm run dev  # starts on http://localhost:5173
```

## Issues
Closes #13

## Test plan
- [ ] `npm run build` succeeds with no TypeScript errors
- [ ] `/` displays catalog grid, filters by product type, toggles hidden listings
- [ ] `/listings/:id` shows detail, reviews, purchase form
- [ ] `/agents/:id` shows wallet balance, listing table, agent info
- [ ] API calls proxy correctly to backend at localhost:3000