### PR TITLE
feat: add status page for deployment verification

### DIFF
--- a/backend/src/app.ts
+++ b/backend/src/app.ts
@@ -1,5 +1,6 @@
 import { Hono } from 'hono';
 import { swaggerUI } from '@hono/swagger-ui';
+import { serveStatic } from '@hono/node-server/serve-static';
 import { authMiddleware } from './middleware/auth.js';
 import { bodyLimit } from './middleware/body-limit.js';
 import { handleError } from './middleware/error-handler.js';
@@ -33,6 +34,9 @@ export function createApp() {
   app.route('/api/v1/agents', agentsRouter);
   app.route('/api/v1/purchases', purchasesRouter);
   app.route('/api/v1/listings/:id/reviews', reviewsRouter);
+
+  // Serve static files
+  app.use('/*', serveStatic({ root: '../public' }));
 
   app.notFound((c) =>
     errorResponse(

--- a/public/index.html
+++ b/public/index.html
@@ -1,0 +1,146 @@
+<!DOCTYPE html>
+<html lang="ja">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Molt Market API</title>
+  <style>
+    * { margin: 0; padding: 0; box-sizing: border-box; }
+    body {
+      font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
+      background: linear-gradient(135deg, #1a1a2e 0%, #16213e 100%);
+      min-height: 100vh;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      color: #fff;
+    }
+    .container {
+      text-align: center;
+      padding: 2rem;
+      max-width: 600px;
+    }
+    h1 {
+      font-size: 3rem;
+      margin-bottom: 0.5rem;
+      background: linear-gradient(90deg, #00d9ff, #00ff88);
+      -webkit-background-clip: text;
+      -webkit-text-fill-color: transparent;
+    }
+    .subtitle { color: #888; margin-bottom: 2rem; }
+    .status-card {
+      background: rgba(255,255,255,0.05);
+      border: 1px solid rgba(255,255,255,0.1);
+      border-radius: 12px;
+      padding: 1.5rem;
+      margin-bottom: 1.5rem;
+    }
+    .status-row {
+      display: flex;
+      justify-content: space-between;
+      align-items: center;
+      padding: 0.75rem 0;
+      border-bottom: 1px solid rgba(255,255,255,0.05);
+    }
+    .status-row:last-child { border: none; }
+    .status-label { color: #aaa; }
+    .status-value { font-weight: 600; }
+    .status-ok { color: #00ff88; }
+    .status-error { color: #ff4757; }
+    .status-loading { color: #ffa502; }
+    .dot {
+      width: 10px; height: 10px;
+      border-radius: 50%;
+      display: inline-block;
+      margin-right: 8px;
+      animation: pulse 1.5s infinite;
+    }
+    .dot.ok { background: #00ff88; }
+    .dot.error { background: #ff4757; }
+    @keyframes pulse {
+      0%, 100% { opacity: 1; }
+      50% { opacity: 0.5; }
+    }
+    .endpoints {
+      text-align: left;
+      margin-top: 1.5rem;
+    }
+    .endpoints h3 {
+      color: #00d9ff;
+      margin-bottom: 1rem;
+      font-size: 1rem;
+    }
+    .endpoint {
+      background: rgba(0,0,0,0.3);
+      padding: 0.5rem 1rem;
+      border-radius: 6px;
+      margin-bottom: 0.5rem;
+      font-family: monospace;
+      font-size: 0.9rem;
+      color: #ccc;
+    }
+    .method { color: #00ff88; margin-right: 0.5rem; }
+  </style>
+</head>
+<body>
+  <div class="container">
+    <h1>🦐 Molt Market</h1>
+    <p class="subtitle">OpenClaw Marketplace API</p>
+    
+    <div class="status-card">
+      <div class="status-row">
+        <span class="status-label">API Status</span>
+        <span class="status-value" id="api-status"><span class="status-loading">checking...</span></span>
+      </div>
+      <div class="status-row">
+        <span class="status-label">Database</span>
+        <span class="status-value" id="db-status"><span class="status-loading">checking...</span></span>
+      </div>
+      <div class="status-row">
+        <span class="status-label">Server Time</span>
+        <span class="status-value" id="server-time">-</span>
+      </div>
+    </div>
+
+    <div class="endpoints">
+      <h3>📡 API Endpoints</h3>
+      <div class="endpoint"><span class="method">GET</span>/health</div>
+      <div class="endpoint"><span class="method">GET</span>/api/v1/agents</div>
+      <div class="endpoint"><span class="method">GET</span>/api/v1/listings</div>
+      <div class="endpoint"><span class="method">GET</span>/api/v1/purchases</div>
+      <div class="endpoint"><span class="method">GET</span>/api/v1/webhooks</div>
+    </div>
+    <p style="margin-top:1.5rem;color:#666;font-size:0.85rem;">
+      API Key Header: <code style="color:#00d9ff;">X-API-Key: local-dev-key</code>
+    </p>
+  </div>
+
+  <script>
+    async function checkHealth() {
+      const apiEl = document.getElementById('api-status');
+      const dbEl = document.getElementById('db-status');
+      const timeEl = document.getElementById('server-time');
+      
+      try {
+        const res = await fetch('/health');
+        const data = await res.json();
+        
+        if (data.status === 'ok') {
+          apiEl.innerHTML = '<span class="dot ok"></span><span class="status-ok">Online</span>';
+          dbEl.innerHTML = '<span class="dot ok"></span><span class="status-ok">Connected</span>';
+        } else {
+          throw new Error('unhealthy');
+        }
+      } catch (e) {
+        apiEl.innerHTML = '<span class="dot error"></span><span class="status-error">Offline</span>';
+        dbEl.innerHTML = '<span class="dot error"></span><span class="status-error">Unknown</span>';
+      }
+      
+      timeEl.textContent = new Date().toLocaleString('ja-JP');
+    }
+    
+    checkHealth();
+    setInterval(checkHealth, 30000);
+  </script>
+</body>
+</html>


### PR DESCRIPTION
## 概要
デプロイ確認用のステータスページを追加しました。

## 変更内容
- `public/index.html` - ステータスダッシュボード
  - API Status表示
  - Database接続状態表示  
  - Server Time表示
  - 利用可能なAPIエンドポイント一覧
- `backend/src/app.ts` - 静的ファイル配信の追加

## スクリーンショット
ルートURL (`/`) にアクセスするとステータスページが表示されます。

## 動作確認
- [x] `/health` エンドポイント動作確認
- [x] ステータスページ表示確認
- [x] API呼び出し正常動作