### PR TITLE
feat: add agent onboarding UI and landing page

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,7 +1,9 @@
 import { Routes, Route, Link } from 'react-router-dom';
+import { LandingPage } from './pages/LandingPage';
 import { CatalogPage } from './pages/CatalogPage';
 import { ListingDetailPage } from './pages/ListingDetailPage';
 import { AgentDashboardPage } from './pages/AgentDashboardPage';
+import { AgentOnboardingPage } from './pages/AgentOnboardingPage';
 
 export function App() {
   return (
@@ -12,7 +14,8 @@ export function App() {
           OpenClaw Marketplace
         </Link>
         <nav>
-          <Link to="/">Browse</Link>
+          <Link to="/browse">Browse</Link>
+          <Link to="/onboarding">Register Agent</Link>
         </nav>
         <div style={{ marginLeft: 'auto', fontSize: '0.8rem', color: '#999' }}>
           Agent Marketplace
@@ -20,9 +23,11 @@ export function App() {
       </header>
       <main className="main">
         <Routes>
-          <Route path="/" element={<CatalogPage />} />
+          <Route path="/" element={<LandingPage />} />
+          <Route path="/browse" element={<CatalogPage />} />
           <Route path="/listings/:id" element={<ListingDetailPage />} />
           <Route path="/agents/:id" element={<AgentDashboardPage />} />
+          <Route path="/onboarding" element={<AgentOnboardingPage />} />
         </Routes>
       </main>
       <footer style={{ textAlign: 'center', padding: '2rem', fontSize: '0.8rem', color: '#999' }}>

--- a/frontend/src/api.ts
+++ b/frontend/src/api.ts
@@ -123,5 +123,12 @@ export const api = {
       method: 'POST',
       body: JSON.stringify(data)
     });
+  },
+
+  registerAgent(data: { owner_id: string; name: string }): Promise<Agent> {
+    return apiFetch('/api/v1/agents', {
+      method: 'POST',
+      body: JSON.stringify(data)
+    });
   }
 };

--- a/frontend/src/pages/AgentOnboardingPage.tsx
+++ b/frontend/src/pages/AgentOnboardingPage.tsx
@@ -1,0 +1,162 @@
+import { useState } from 'react';
+import { useNavigate, Link } from 'react-router-dom';
+import { api, type Agent } from '../api';
+
+type Step = 'form' | 'submitting' | 'done';
+
+export function AgentOnboardingPage() {
+  const navigate = useNavigate();
+  const [step, setStep] = useState<Step>('form');
+  const [ownerId, setOwnerId] = useState('');
+  const [name, setName] = useState('');
+  const [error, setError] = useState<string | null>(null);
+  const [agent, setAgent] = useState<Agent | null>(null);
+
+  const handleSubmit = async (e: React.FormEvent<HTMLFormElement>) => {
+    e.preventDefault();
+    setError(null);
+    setStep('submitting');
+
+    try {
+      const created = await api.registerAgent({ owner_id: ownerId, name });
+      setAgent(created);
+      setStep('done');
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Failed to register agent.');
+      setStep('form');
+    }
+  };
+
+  if (step === 'done' && agent) {
+    return (
+      <div>
+        <div style={{ marginBottom: '1rem' }}>
+          <Link to="/">&larr; Back to Browse</Link>
+        </div>
+
+        <div className="card" style={{ marginBottom: '1.5rem', textAlign: 'center' }}>
+          <div style={{ fontSize: '2.5rem', marginBottom: '0.5rem' }}>&#x2705;</div>
+          <h1 style={{ fontSize: '1.5rem', marginBottom: '0.5rem' }}>Agent Registered</h1>
+          <p style={{ color: '#666', marginBottom: '1.5rem' }}>
+            Your agent is ready. A wallet and DID have been automatically generated.
+          </p>
+        </div>
+
+        <div className="card" style={{ marginBottom: '1rem' }}>
+          <h2 style={{ fontSize: '1.1rem', marginBottom: '1rem' }}>Agent Details</h2>
+
+          <div style={{ marginBottom: '0.75rem' }}>
+            <div style={{ fontSize: '0.8rem', color: '#666', marginBottom: '0.15rem' }}>Name</div>
+            <div style={{ fontWeight: 600 }}>{agent.name}</div>
+          </div>
+
+          <div style={{ marginBottom: '0.75rem' }}>
+            <div style={{ fontSize: '0.8rem', color: '#666', marginBottom: '0.15rem' }}>Owner</div>
+            <div>{agent.owner_id}</div>
+          </div>
+
+          <div style={{ marginBottom: '0.75rem' }}>
+            <div style={{ fontSize: '0.8rem', color: '#666', marginBottom: '0.15rem' }}>Agent ID</div>
+            <div className="wallet-address">{agent.id}</div>
+          </div>
+
+          <div style={{ marginBottom: '0.75rem' }}>
+            <div style={{ fontSize: '0.8rem', color: '#666', marginBottom: '0.15rem' }}>DID</div>
+            <div className="wallet-address">{agent.did}</div>
+          </div>
+
+          <div>
+            <div style={{ fontSize: '0.8rem', color: '#666', marginBottom: '0.15rem' }}>Wallet Address</div>
+            <div className="wallet-address">{agent.wallet_address}</div>
+          </div>
+        </div>
+
+        <div style={{ display: 'flex', gap: '0.75rem' }}>
+          <button
+            className="btn btn-primary"
+            onClick={() => navigate(`/agents/${agent.id}`)}
+          >
+            Go to Dashboard
+          </button>
+          <button
+            className="btn btn-secondary"
+            onClick={() => {
+              setStep('form');
+              setOwnerId('');
+              setName('');
+              setAgent(null);
+            }}
+          >
+            Register Another
+          </button>
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div>
+      <div style={{ marginBottom: '1rem' }}>
+        <Link to="/">&larr; Back to Browse</Link>
+      </div>
+
+      <h1 className="section-title">Register a New Agent</h1>
+      <p style={{ color: '#666', marginBottom: '1.5rem' }}>
+        Register your AI agent to start selling products on the marketplace.
+        A wallet and decentralized identity (DID) will be generated automatically.
+      </p>
+
+      {error && (
+        <div className="card" style={{ marginBottom: '1rem', background: '#fce4ec', color: '#c62828' }}>
+          {error}
+        </div>
+      )}
+
+      <div className="card">
+        <form onSubmit={handleSubmit}>
+          <div className="form-group">
+            <label htmlFor="owner-id">Owner ID</label>
+            <input
+              id="owner-id"
+              type="text"
+              placeholder="e.g. owner-alice"
+              value={ownerId}
+              onChange={(e) => setOwnerId(e.target.value)}
+              required
+            />
+          </div>
+
+          <div className="form-group">
+            <label htmlFor="agent-name">Agent Name</label>
+            <input
+              id="agent-name"
+              type="text"
+              placeholder="e.g. My Trading Agent"
+              value={name}
+              onChange={(e) => setName(e.target.value)}
+              required
+            />
+          </div>
+
+          <button
+            type="submit"
+            className="btn btn-primary"
+            disabled={step === 'submitting'}
+            style={{ width: '100%', marginTop: '0.5rem' }}
+          >
+            {step === 'submitting' ? 'Registering...' : 'Register Agent'}
+          </button>
+        </form>
+      </div>
+
+      <div className="card" style={{ marginTop: '1.5rem' }}>
+        <h3 style={{ fontSize: '0.95rem', marginBottom: '0.75rem' }}>What happens when you register?</h3>
+        <ol style={{ paddingLeft: '1.25rem', fontSize: '0.85rem', color: '#555', lineHeight: '1.8' }}>
+          <li>An Ethereum wallet is generated for your agent</li>
+          <li>A decentralized identity (DID) is assigned: <code>did:ethr:&lt;address&gt;</code></li>
+          <li>Your agent is ready to list and sell products</li>
+        </ol>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/pages/LandingPage.tsx
+++ b/frontend/src/pages/LandingPage.tsx
@@ -1,0 +1,108 @@
+import { Link } from 'react-router-dom';
+
+const steps = [
+  {
+    num: '1',
+    title: 'Register Your Agent',
+    desc: 'Owner ID と Agent Name を入力するだけ。Ethereum ウォレットと分散型ID (DID) が自動生成されます。',
+  },
+  {
+    num: '2',
+    title: 'List Products',
+    desc: '登録した Agent で AI が生成したソフトウェアプロダクトを出品。価格は USDC で設定します。',
+  },
+  {
+    num: '3',
+    title: 'Earn USDC',
+    desc: '購入が入ると USDC が Agent のウォレットに自動送金。ダッシュボードで残高を確認できます。',
+  },
+];
+
+export function LandingPage() {
+  return (
+    <div>
+      {/* Hero */}
+      <section style={{ textAlign: 'center', padding: '3rem 0 2rem' }}>
+        <h1 style={{ fontSize: '2rem', fontWeight: 800, marginBottom: '0.75rem' }}>
+          AI Agent Marketplace
+        </h1>
+        <p style={{ fontSize: '1.1rem', color: '#555', maxWidth: '600px', margin: '0 auto 2rem' }}>
+          AI エージェントがソフトウェアを自律的に出品・販売・決済する、
+          API ファーストのマーケットプレイスです。
+        </p>
+        <div style={{ display: 'flex', gap: '0.75rem', justifyContent: 'center', flexWrap: 'wrap' }}>
+          <Link to="/onboarding" className="btn btn-primary" style={{ fontSize: '1rem', padding: '0.75rem 2rem' }}>
+            Agent を登録する
+          </Link>
+          <Link to="/browse" className="btn btn-secondary" style={{ fontSize: '1rem', padding: '0.75rem 2rem' }}>
+            プロダクトを見る
+          </Link>
+        </div>
+      </section>
+
+      {/* How it works */}
+      <section style={{ padding: '2rem 0' }}>
+        <h2 className="section-title" style={{ textAlign: 'center', marginBottom: '1.5rem' }}>
+          Agent オンボーディングの流れ
+        </h2>
+        <div className="stat-grid" style={{ gridTemplateColumns: 'repeat(auto-fill, minmax(280px, 1fr))' }}>
+          {steps.map((s) => (
+            <div key={s.num} className="card" style={{ textAlign: 'center' }}>
+              <div style={{
+                width: '40px', height: '40px', borderRadius: '50%',
+                background: '#0066cc', color: '#fff', fontWeight: 700, fontSize: '1.1rem',
+                display: 'inline-flex', alignItems: 'center', justifyContent: 'center',
+                marginBottom: '0.75rem',
+              }}>
+                {s.num}
+              </div>
+              <h3 style={{ fontSize: '1rem', marginBottom: '0.5rem' }}>{s.title}</h3>
+              <p style={{ fontSize: '0.85rem', color: '#666', lineHeight: '1.6' }}>{s.desc}</p>
+            </div>
+          ))}
+        </div>
+      </section>
+
+      {/* What you get */}
+      <section style={{ padding: '2rem 0' }}>
+        <h2 className="section-title" style={{ textAlign: 'center', marginBottom: '1.5rem' }}>
+          登録すると何が得られる？
+        </h2>
+        <div className="card" style={{ maxWidth: '640px', margin: '0 auto' }}>
+          <table style={{ width: '100%', borderCollapse: 'collapse', fontSize: '0.9rem' }}>
+            <tbody>
+              {[
+                ['Ethereum Wallet', 'HD ウォレットから自動導出。秘密鍵は KMS で管理。'],
+                ['DID (分散型ID)', 'did:ethr:<address> 形式の W3C 準拠 ID。'],
+                ['Agent Dashboard', 'ウォレット残高・出品一覧・レビューを一画面で確認。'],
+                ['USDC 自動決済', '購入時に USDC がオンチェーンで Agent ウォレットへ送金。'],
+              ].map(([label, desc]) => (
+                <tr key={label} style={{ borderBottom: '1px solid #eee' }}>
+                  <td style={{ padding: '0.75rem 0.5rem', fontWeight: 600, whiteSpace: 'nowrap', verticalAlign: 'top' }}>
+                    {label}
+                  </td>
+                  <td style={{ padding: '0.75rem 0.5rem', color: '#555' }}>{desc}</td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      </section>
+
+      {/* CTA */}
+      <section style={{ textAlign: 'center', padding: '2rem 0 3rem' }}>
+        <div className="card" style={{ maxWidth: '480px', margin: '0 auto', padding: '2rem' }}>
+          <h3 style={{ fontSize: '1.1rem', marginBottom: '0.5rem' }}>
+            必要なのは Owner ID と Agent Name だけ
+          </h3>
+          <p style={{ fontSize: '0.85rem', color: '#666', marginBottom: '1.25rem' }}>
+            ウォレットも DID も自動生成。30 秒で始められます。
+          </p>
+          <Link to="/onboarding" className="btn btn-primary" style={{ fontSize: '1rem', padding: '0.75rem 2rem' }}>
+            Agent を登録する
+          </Link>
+        </div>
+      </section>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- ランディングページ (`/`) を新設し、Agent オンボーディングの流れ（登録→出品→収益化）を説明
- Agent 登録フォーム (`/onboarding`) を追加。Owner ID と Agent Name を入力すると DID・ウォレットが自動生成され、結果を表示
- 商品一覧を `/browse` に移動し、ヘッダーに「Register Agent」ナビリンクを追加

## Changes
- `LandingPage.tsx` — Hero / 3ステップ説明 / 機能テーブル / CTA セクション
- `AgentOnboardingPage.tsx` — 登録フォーム / 完了画面（DID・Wallet表示）/ ダッシュボード遷移
- `api.ts` — `registerAgent()` メソッド追加
- `App.tsx` — ルーティング変更 (`/` → Landing, `/browse` → Catalog, `/onboarding` → Registration)

## Test plan
- [ ] `/` にアクセスしてランディングページが表示されること
- [ ] 「Agent を登録する」ボタンで `/onboarding` に遷移すること
- [ ] フォームに入力して登録すると、Agent ID / DID / Wallet Address が表示されること
- [ ] 「Go to Dashboard」でダッシュボードに遷移すること
- [ ] 「プロダクトを見る」で `/browse` の商品一覧が表示されること
- [ ] ヘッダーの Browse / Register Agent リンクが正しく動作すること

🤖 Generated with [Claude Code](https://claude.com/claude-code)