### PR TITLE
fix: docker compose local dev environment and improve onboarding UX

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
 node_modules/
 dist/
 .env
+contracts/cache/
+contracts/out/

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,29 @@
+.PHONY: start stop restart logs status clean setup
+
+# Start all services (infra + API + worker + frontend)
+start:
+	docker compose up -d --build
+
+# Stop all services
+stop:
+	docker compose down
+
+# Restart all services
+restart: stop start
+
+# Tail logs for all services
+logs:
+	docker compose logs -f
+
+# Show running services
+status:
+	docker compose ps
+
+# Stop and remove volumes (full reset)
+clean:
+	docker compose down -v
+
+# Install dependencies locally (for IDE support)
+setup:
+	cd backend && npm install
+	cd frontend && npm install

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -6,8 +6,7 @@ COPY package.json package-lock.json* ./
 RUN npm install
 
 COPY . .
-RUN npm run build
 
 EXPOSE 3000
 
-CMD ["node", "dist/index.js"]
+CMD ["npx", "tsx", "src/index.ts"]

--- a/backend/tsconfig.json
+++ b/backend/tsconfig.json
@@ -13,5 +13,6 @@
     "resolveJsonModule": true,
     "types": ["node"]
   },
-  "include": ["src", "tests", "vitest.config.ts"]
+  "include": ["src"],
+  "exclude": ["tests", "vitest.config.ts"]
 }

--- a/contracts/deploy.sh
+++ b/contracts/deploy.sh
@@ -20,6 +20,7 @@ forge build
 
 echo "Deploying TestUSDC..."
 DEPLOY_OUTPUT=$(forge create src/TestUSDC.sol:TestUSDC \
+  --broadcast \
   --rpc-url "$ANVIL_RPC" \
   --private-key "$DEPLOYER_KEY" \
   --constructor-args "$INITIAL_SUPPLY")

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,8 +5,6 @@ services:
       POSTGRES_DB: openclaw
       POSTGRES_USER: postgres
       POSTGRES_PASSWORD: postgres
-    ports:
-      - '5432:5432'
     volumes:
       - db_data:/var/lib/postgresql/data
     healthcheck:
@@ -17,8 +15,6 @@ services:
 
   redis:
     image: redis:7-alpine
-    ports:
-      - '6379:6379'
     healthcheck:
       test: ['CMD', 'redis-cli', 'ping']
       interval: 3s
@@ -27,9 +23,7 @@ services:
 
   anvil:
     image: ghcr.io/foundry-rs/foundry:latest
-    command: ['anvil', '--host', '0.0.0.0', '--port', '8545']
-    ports:
-      - '8545:8545'
+    entrypoint: ['anvil', '--host', '0.0.0.0', '--port', '8545']
     healthcheck:
       test: ['CMD-SHELL', 'cast block-number --rpc-url http://localhost:8545 || exit 1']
       interval: 3s
@@ -39,6 +33,7 @@ services:
   # Deploy TestUSDC ERC-20 to Anvil
   deploy-usdc:
     image: ghcr.io/foundry-rs/foundry:latest
+    user: root
     volumes:
       - ./contracts:/contracts
       - usdc_data:/data
@@ -50,7 +45,7 @@ services:
   # Moltbook mock marketing API
   moltbook-mock:
     build: ./backend
-    command: ['npx', 'tsx', '/scripts/moltbook-mock.ts']
+    command: ['sh', '-c', 'cd /app && NODE_PATH=/app/node_modules npx tsx /scripts/moltbook-mock.ts']
     volumes:
       - ./scripts:/scripts
     ports:
@@ -61,7 +56,7 @@ services:
   # Run DB migrations
   migrate:
     build: ./backend
-    command: ['sh', '-c', 'npx node-pg-migrate -m /migrations -d $DATABASE_URL up']
+    command: ['sh', '-c', 'npx node-pg-migrate -m /migrations up']
     volumes:
       - ./migrations:/migrations
     environment:
@@ -73,7 +68,7 @@ services:
   # Seed sample data
   seed:
     build: ./backend
-    command: ['npx', 'tsx', '/scripts/seed.ts']
+    command: ['sh', '-c', 'cd /app && NODE_PATH=/app/node_modules npx tsx /scripts/seed.ts']
     volumes:
       - ./scripts:/scripts
     environment:
@@ -98,7 +93,7 @@ services:
     ports:
       - '3000:3000'
     volumes:
-      - usdc_data:/data
+      - usdc_data:/data:ro
     depends_on:
       migrate:
         condition: service_completed_successfully
@@ -120,7 +115,7 @@ services:
       MOLTBOOK_API_URL: http://moltbook-mock:4000
       MOLTBOOK_API_KEY: mock-key
     volumes:
-      - usdc_data:/data
+      - usdc_data:/data:ro
     depends_on:
       api:
         condition: service_started

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -1,7 +1,7 @@
 FROM node:20-alpine
 WORKDIR /app
 COPY package*.json ./
-RUN npm ci
+RUN npm install
 COPY . .
 EXPOSE 5173
 CMD ["npx", "vite", "--host", "0.0.0.0"]

--- a/frontend/src/pages/AgentOnboardingPage.tsx
+++ b/frontend/src/pages/AgentOnboardingPage.tsx
@@ -36,14 +36,14 @@ export function AgentOnboardingPage() {
 
         <div className="card" style={{ marginBottom: '1.5rem', textAlign: 'center' }}>
           <div style={{ fontSize: '2.5rem', marginBottom: '0.5rem' }}>&#x2705;</div>
-          <h1 style={{ fontSize: '1.5rem', marginBottom: '0.5rem' }}>Agent Registered</h1>
+          <h1 style={{ fontSize: '1.5rem', marginBottom: '0.5rem' }}>Agent 登録完了</h1>
           <p style={{ color: '#666', marginBottom: '1.5rem' }}>
-            Your agent is ready. A wallet and DID have been automatically generated.
+            ウォレットと DID が自動生成されました。ダッシュボードから出品を始められます。
           </p>
         </div>
 
         <div className="card" style={{ marginBottom: '1rem' }}>
-          <h2 style={{ fontSize: '1.1rem', marginBottom: '1rem' }}>Agent Details</h2>
+          <h2 style={{ fontSize: '1.1rem', marginBottom: '1rem' }}>登録情報</h2>
 
           <div style={{ marginBottom: '0.75rem' }}>
             <div style={{ fontSize: '0.8rem', color: '#666', marginBottom: '0.15rem' }}>Name</div>
@@ -76,7 +76,7 @@ export function AgentOnboardingPage() {
             className="btn btn-primary"
             onClick={() => navigate(`/agents/${agent.id}`)}
           >
-            Go to Dashboard
+            ダッシュボードへ
           </button>
           <button
             className="btn btn-secondary"
@@ -87,7 +87,7 @@ export function AgentOnboardingPage() {
               setAgent(null);
             }}
           >
-            Register Another
+            別の Agent を登録
           </button>
         </div>
       </div>
@@ -100,11 +100,21 @@ export function AgentOnboardingPage() {
         <Link to="/">&larr; Back to Browse</Link>
       </div>
 
-      <h1 className="section-title">Register a New Agent</h1>
-      <p style={{ color: '#666', marginBottom: '1.5rem' }}>
-        Register your AI agent to start selling products on the marketplace.
-        A wallet and decentralized identity (DID) will be generated automatically.
-      </p>
+      <h1 className="section-title">Agent をマーケットプレイスに登録する</h1>
+
+      {/* What is this page for */}
+      <div className="card" style={{ marginBottom: '1.5rem', background: '#f0f7ff', border: '1px solid #cce0ff' }}>
+        <h3 style={{ fontSize: '1rem', marginBottom: '0.5rem' }}>このページでできること</h3>
+        <p style={{ fontSize: '0.9rem', color: '#333', lineHeight: '1.7', marginBottom: '0.75rem' }}>
+          AI エージェントを OpenClaw Marketplace に登録します。
+          登録すると、エージェント専用の <strong>Ethereum ウォレット</strong> と
+          <strong>分散型 ID (DID)</strong> が自動で発行され、
+          すぐにプロダクトの出品と USDC での売上受取を始められます。
+        </p>
+        <p style={{ fontSize: '0.85rem', color: '#555' }}>
+          入力が必要なのは下記の <strong>2 項目だけ</strong>です。あとは全て自動で設定されます。
+        </p>
+      </div>
 
       {error && (
         <div className="card" style={{ marginBottom: '1rem', background: '#fce4ec', color: '#c62828' }}>
@@ -116,10 +126,13 @@ export function AgentOnboardingPage() {
         <form onSubmit={handleSubmit}>
           <div className="form-group">
             <label htmlFor="owner-id">Owner ID</label>
+            <p style={{ fontSize: '0.8rem', color: '#888', marginBottom: '0.35rem' }}>
+              Agent の所有者を識別する ID です。あなたのユーザー名やメールアドレスなど、任意の文字列を入力してください。
+            </p>
             <input
               id="owner-id"
               type="text"
-              placeholder="e.g. owner-alice"
+              placeholder="例: owner-alice, alice@example.com"
               value={ownerId}
               onChange={(e) => setOwnerId(e.target.value)}
               required
@@ -128,10 +141,13 @@ export function AgentOnboardingPage() {
 
           <div className="form-group">
             <label htmlFor="agent-name">Agent Name</label>
+            <p style={{ fontSize: '0.8rem', color: '#888', marginBottom: '0.35rem' }}>
+              マーケットプレイスに表示される Agent の名前です。後から出品する商品に紐づきます。
+            </p>
             <input
               id="agent-name"
               type="text"
-              placeholder="e.g. My Trading Agent"
+              placeholder="例: OpenClaw Alpha, My Trading Bot"
               value={name}
               onChange={(e) => setName(e.target.value)}
               required
@@ -144,18 +160,43 @@ export function AgentOnboardingPage() {
             disabled={step === 'submitting'}
             style={{ width: '100%', marginTop: '0.5rem' }}
           >
-            {step === 'submitting' ? 'Registering...' : 'Register Agent'}
+            {step === 'submitting' ? '登録中...' : 'Agent を登録する'}
           </button>
         </form>
       </div>
 
+      {/* What happens after registration */}
       <div className="card" style={{ marginTop: '1.5rem' }}>
-        <h3 style={{ fontSize: '0.95rem', marginBottom: '0.75rem' }}>What happens when you register?</h3>
-        <ol style={{ paddingLeft: '1.25rem', fontSize: '0.85rem', color: '#555', lineHeight: '1.8' }}>
-          <li>An Ethereum wallet is generated for your agent</li>
-          <li>A decentralized identity (DID) is assigned: <code>did:ethr:&lt;address&gt;</code></li>
-          <li>Your agent is ready to list and sell products</li>
+        <h3 style={{ fontSize: '0.95rem', marginBottom: '0.75rem' }}>登録すると何が起きる？</h3>
+        <ol style={{ paddingLeft: '1.25rem', fontSize: '0.85rem', color: '#555', lineHeight: '2' }}>
+          <li><strong>Ethereum ウォレット生成</strong> &mdash; Agent 専用のアドレスが HD ウォレットから導出されます</li>
+          <li><strong>DID 発行</strong> &mdash; <code>did:ethr:&lt;address&gt;</code> 形式の W3C 準拠 ID が付与されます</li>
+          <li><strong>ダッシュボード利用可能</strong> &mdash; 残高確認・商品出品・レビュー管理がすぐに使えます</li>
         </ol>
+      </div>
+
+      {/* Next steps after registration */}
+      <div className="card" style={{ marginTop: '1rem' }}>
+        <h3 style={{ fontSize: '0.95rem', marginBottom: '0.75rem' }}>登録後の流れ</h3>
+        <div style={{ display: 'grid', gridTemplateColumns: 'repeat(auto-fill, minmax(200px, 1fr))', gap: '0.75rem' }}>
+          {[
+            { step: '1', title: 'Agent 登録', desc: 'このページで完了', done: true },
+            { step: '2', title: 'プロダクト出品', desc: 'API 経由で商品を登録', done: false },
+            { step: '3', title: 'USDC を受け取る', desc: '購入時に自動送金', done: false },
+          ].map((s) => (
+            <div key={s.step} style={{
+              padding: '0.75rem',
+              borderRadius: '8px',
+              background: s.done ? '#e8f5e9' : '#f5f5f5',
+              textAlign: 'center',
+            }}>
+              <div style={{ fontWeight: 700, fontSize: '0.85rem', marginBottom: '0.25rem' }}>
+                Step {s.step}: {s.title}
+              </div>
+              <div style={{ fontSize: '0.8rem', color: '#666' }}>{s.desc}</div>
+            </div>
+          ))}
+        </div>
       </div>
     </div>
   );

--- a/scripts/seed.ts
+++ b/scripts/seed.ts
@@ -1,4 +1,3 @@
-import 'dotenv/config';
 import { Pool } from 'pg';
 
 const pool = new Pool({ connectionString: process.env.DATABASE_URL });


### PR DESCRIPTION
## Summary
- `make start` でローカル開発環境が一発で立ち上がるように Docker Compose の各種問題を修正
- オンボーディング画面の日本語化と UX 改善

## Changes
- **Makefile**: `start` / `stop` / `restart` / `logs` / `status` / `clean` ターゲット追加
- **Anvil**: `command` → `entrypoint` に変更し `--host 0.0.0.0` が正しく渡るように修正
- **migrate**: `-d $DATABASE_URL` フラグ除去（ENV 自動参照）
- **deploy-usdc**: `--broadcast` フラグ追加、`user: root` で Volume 書き込み権限確保
- **seed/moltbook-mock**: `NODE_PATH=/app/node_modules` でモジュール解決修正
- **docker-compose**: Redis/Postgres/Anvil のホスト `ports` 除去（ポート競合回避）
- **backend Dockerfile**: `tsc` ビルド除去 → `tsx` 直接実行に変更
- **backend tsconfig**: `tests` を `exclude` に移動
- **frontend Dockerfile**: `npm ci` → `npm install`（lock file 不要）
- **.gitignore**: `contracts/cache/` `contracts/out/` 追加
- **AgentOnboardingPage**: 日本語コピー、ステップ説明、登録後の流れを追加

## Test plan
- [ ] `make start` で全サービスが起動すること
- [ ] `curl -H "x-api-key: local-dev-key" http://localhost:3000/api/v1/listings` でデータ取得
- [ ] http://localhost:5173 でフロントエンドが表示されること
- [ ] `/onboarding` でAgent登録フォームが日本語で表示されること

🤖 Generated with [Claude Code](https://claude.com/claude-code)