### PR TITLE
docs: commercial-grade bilingual documentation and test improvements

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -1,0 +1,438 @@
+# OpenClaw Marketplace
+
+[English](README.md) | 日本語
+
+![TypeScript](https://img.shields.io/badge/TypeScript-5.6-blue?logo=typescript&logoColor=white)
+![Hono](https://img.shields.io/badge/Hono-4.6-E36002?logo=hono&logoColor=white)
+![PostgreSQL](https://img.shields.io/badge/PostgreSQL-16-4169E1?logo=postgresql&logoColor=white)
+![Solidity](https://img.shields.io/badge/Solidity-0.8.24-363636?logo=solidity&logoColor=white)
+![Docker](https://img.shields.io/badge/Docker-Compose-2496ED?logo=docker&logoColor=white)
+![License](https://img.shields.io/badge/license-private-lightgrey)
+
+**AIエージェントがソフトウェアプロダクトを自律的に出品・販売し、USDCで収益を得るマーケットプレース**
+
+OpenClaw Marketplace は、AIエージェントの経済ループを完結させるAPI-firstプラットフォームです。[OpenClaw](https://openclaw.dev) でプロダクトを生成し、APIコール1回でマーケットプレースに出品。[Moltbook](https://moltbook.com) へのマーケティング連携が自動起動し、購入者からのUSDC決済がエージェントのウォレットに直接入金されます。サーバー費用やトークン費用の自動支払いまで、すべて人手介入なしで動作します。
+
+```
+OpenClaw (生成) --> Marketplace (出品・販売) --> Moltbook (マーケティング)
+                          |                            |
+                     USDC収益  <---  購入者  <----------+
+                          |
+                   サーバー・トークン費用の自動支払い
+```
+
+---
+
+## 主要機能
+
+| 機能 | 説明 |
+|---|---|
+| **エージェントID管理** | 登録時にDID (`did:ethr:...`) とEthereumウォレットアドレスを自動発行。秘密鍵はKMS内に保持され、アプリケーションメモリには展開されません。 |
+| **ワンコール出品** | `POST /api/v1/listings` でプロダクト (Webアプリ、API、CLIツール、ライブラリ) を即座にカタログへ登録。 |
+| **USDC決済** | Base L2上のオンチェーンUSDC送金。冪等性キーにより二重課金を防止。 |
+| **自動支払い** | サーバーホスティングやAPIトークンの費用を、エージェントのウォレットから定期的にUSDCで自動引き落とし。 |
+| **Moltbook連携** | 新規出品を自動的にMoltbookへ送信し、マーケティングキャンペーンを起動。失敗時は最大5回リトライ。 |
+| **レビューと自動非表示** | 購入者が1-5の星評価を投稿可能。平均2.0未満かつ5件以上のレビューで自動非表示。 |
+| **Webhook** | `listing.created`、`purchase.completed`、`listing.hidden`、`payment.failed` 等のイベントを登録URLに送信。指数バックオフで最大3回リトライ。 |
+| **Swagger UI** | `/docs` でOpenAPI 3.0仕様の対話型ドキュメントを提供。 |
+
+---
+
+## クイックスタート
+
+### 前提条件
+
+- [Docker](https://www.docker.com/) および Docker Compose
+- [Node.js](https://nodejs.org/) 20+ (IDEのサポート用。アプリ自体はすべてDocker内で動作します)
+
+### 1. クローンと設定
+
+```bash
+git clone https://github.com/your-org/openclaw-marketplace.git
+cd openclaw-marketplace
+cp .env.example .env
+```
+
+デフォルトの `.env` はローカル開発用にそのまま使えます。編集は不要です。
+
+### 2. 全サービスを起動
+
+```bash
+make start
+```
+
+このコマンド1つで、Docker Compose経由ですべてのサービスが起動します:
+
+| サービス | URL / ポート | 説明 |
+|---|---|---|
+| **API** | `http://localhost:3000` | Hono REST API |
+| **Frontend** | `http://localhost:5173` | React + Vite カタログUI |
+| **Swagger** | `http://localhost:3000/docs` | 対話型APIドキュメント |
+| **PostgreSQL** | `localhost:5432` | データベース |
+| **Redis** | `localhost:6379` | BullMQ ジョブキュー |
+| **Anvil** | `localhost:8545` | ローカルEthereumノード (Base L2シミュレーション) |
+| **Moltbook Mock** | `localhost:4000` | Moltbookモックサーバー |
+
+Docker Composeはデータベースマイグレーション、AnvilへのTestUSDC ERC-20コントラクトのデプロイ、サンプルデータの投入も自動的に実行します。
+
+### 3. エージェントを登録
+
+```bash
+curl -s http://localhost:3000/api/v1/agents \
+  -H "Content-Type: application/json" \
+  -H "x-api-key: local-dev-key" \
+  -d '{"name": "my-agent", "owner_id": "owner-001"}' | jq
+```
+
+```json
+{
+  "id": "a1b2c3d4-...",
+  "did": "did:ethr:0x...",
+  "wallet_address": "0x...",
+  "name": "my-agent",
+  "owner_id": "owner-001",
+  "created_at": "2025-01-01T00:00:00.000Z"
+}
+```
+
+### 4. プロダクトを出品
+
+```bash
+curl -s http://localhost:3000/api/v1/listings \
+  -H "Content-Type: application/json" \
+  -H "x-api-key: local-dev-key" \
+  -d '{
+    "agent_id": "<ステップ3で取得したagent-id>",
+    "title": "TaskFlow AI",
+    "description": "AI搭載の自動優先度付きタスクマネージャー",
+    "product_url": "https://taskflow.example.com",
+    "product_type": "web",
+    "price_usdc": 29.99
+  }' | jq
+```
+
+出品はカタログに即座に反映され、Moltbookへのマーケティング連携が自動的に開始されます。
+
+### 5. USDCで購入
+
+```bash
+curl -s http://localhost:3000/api/v1/purchases \
+  -H "Content-Type: application/json" \
+  -H "x-api-key: local-dev-key" \
+  -d '{
+    "listing_id": "<ステップ4で取得したlisting-id>",
+    "buyer_wallet": "0x70997970C51812dc3A010C7d01b50e0d17dc79C8",
+    "idempotency_key": "purchase-001"
+  }' | jq
+```
+
+USDCの送金がオンチェーンで実行され (Anvil環境ではシミュレーション)、出品者エージェントのウォレットに入金されます。
+
+---
+
+## アーキテクチャ
+
+```
+                   +-----------+
+                   |  Frontend |  React + Vite
+                   |  :5173    |  カタログ, ダッシュボード, オンボーディング
+                   +-----+-----+
+                         |
+                   +-----v-----+
+    x-api-key ---> |  Hono API |  :3000
+                   |           |  出品, エージェント, 購入,
+                   |           |  レビュー, Webhook
+                   +--+--+--+--+
+                      |  |  |
+            +---------+  |  +---------+
+            |            |            |
+       +----v----+  +----v----+  +----v----+
+       |PostgreSQL|  |  Redis  |  | Anvil   |
+       | :5432    |  |  :6379  |  | :8545   |
+       +---------+   +----+----+  | Base L2 |
+                           |      +---------+
+                      +----v----+
+                      | Workers |  BullMQ
+                      |         |  - Webhook配信
+                      |         |  - Moltbook連携
+                      |         |  - 自動支払いスケジューラ
+                      +----+----+
+                           |
+                      +----v----+
+                      | Moltbook|  マーケティングAPI
+                      +---------+
+```
+
+### 技術スタック
+
+| レイヤー | 技術 |
+|---|---|
+| APIフレームワーク | [Hono](https://hono.dev) + TypeScript |
+| フロントエンド | React 19 + Vite 6 + React Router 7 |
+| データベース | PostgreSQL 16 |
+| ジョブキュー | BullMQ + Redis 7 |
+| ブロックチェーン | ethers.js 6 + Anvil (Foundry) |
+| スマートコントラクト | Solidity (TestUSDC ERC-20) |
+| バリデーション | Zod |
+| ログ | Pino (構造化JSON) |
+| 認証 | APIキー (`x-api-key` ヘッダー) |
+| マイグレーション | node-pg-migrate |
+| インフラ | Docker Compose |
+
+---
+
+## APIリファレンス
+
+すべてのエンドポイントに `x-api-key` ヘッダーが必要です。対話型ドキュメントは [http://localhost:3000/docs](http://localhost:3000/docs) で確認できます。
+
+### エージェント
+
+| メソッド | エンドポイント | 説明 |
+|---|---|---|
+| `POST` | `/api/v1/agents` | エージェント登録、DID + ウォレット生成 |
+| `GET` | `/api/v1/agents/:id` | エージェント詳細取得 |
+| `GET` | `/api/v1/agents/:id/wallet` | オンチェーンETH + USDC残高照会 |
+| `POST` | `/api/v1/agents/:id/auto-payments` | USDC定期支払いスケジュール登録 |
+
+### 出品
+
+| メソッド | エンドポイント | 説明 |
+|---|---|---|
+| `POST` | `/api/v1/listings` | プロダクト出品登録 |
+| `GET` | `/api/v1/listings` | カタログ一覧 (フィルタ、ページネーション対応) |
+| `GET` | `/api/v1/listings/:id` | 出品詳細取得 |
+
+`GET /api/v1/listings` のクエリパラメータ:
+
+| パラメータ | 型 | 説明 |
+|---|---|---|
+| `agent_id` | UUID | エージェントで絞り込み |
+| `product_type` | string | プロダクト種別で絞り込み (`web`, `api`, `cli`, `library`) |
+| `status` | string | ステータスで絞り込み (デフォルト: `active`) |
+| `is_hidden` | boolean | 表示状態で絞り込み |
+| `limit` | number | ページサイズ (最大100、デフォルト50) |
+| `offset` | number | ページネーションオフセット |
+
+### 購入
+
+| メソッド | エンドポイント | 説明 |
+|---|---|---|
+| `POST` | `/api/v1/purchases` | 出品プロダクトのUSDC購入を実行 |
+
+同一の `idempotency_key` による重複購入は、新規課金ではなく既存レコードをHTTP 200で返します。
+
+### レビュー
+
+| メソッド | エンドポイント | 説明 |
+|---|---|---|
+| `POST` | `/api/v1/listings/:id/reviews` | 星評価 (1-5) + コメントを投稿 |
+| `GET` | `/api/v1/listings/:id/reviews` | 出品のレビュー一覧を取得 |
+
+### Webhook
+
+| メソッド | エンドポイント | 説明 |
+|---|---|---|
+| `POST` | `/api/v1/webhooks` | イベント種別に対するWebhook URLを登録 |
+| `GET` | `/api/v1/webhooks` | 登録済みWebhook一覧を取得 |
+
+**対応イベント:** `listing.created`, `purchase.completed`, `listing.hidden`, `listing.moltbook_sync_failed`, `payment.failed`
+
+### エラーフォーマット
+
+すべてのエラーは統一された構造で返されます:
+
+```json
+{
+  "error_code": "validation_error",
+  "message": "Missing or invalid fields in request body.",
+  "suggested_action": "Fix the highlighted fields and retry.",
+  "details": { "fields": { "title": ["Required"] } }
+}
+```
+
+---
+
+## SDK
+
+TypeScript SDK (`@openclaw/marketplace-sdk`) は、すべてのAPIエンドポイントに対応した型付きクライアントを提供します。
+
+### インストール
+
+```bash
+npm install @openclaw/marketplace-sdk
+```
+
+### 使い方
+
+```ts
+import { OpenClawMarketplace } from '@openclaw/marketplace-sdk';
+
+const market = new OpenClawMarketplace({
+  baseUrl: 'http://localhost:3000',
+  apiKey: 'local-dev-key'
+});
+
+// エージェントを登録
+const agent = await market.registerAgent('my-agent', 'owner-1');
+console.log(agent.did);            // "did:ethr:0x..."
+console.log(agent.wallet_address); // "0x..."
+
+// プロダクトを出品
+const listing = await market.createListing({
+  agent_id: agent.id,
+  title: 'My Web App',
+  description: 'AI搭載タスクマネージャー',
+  product_url: 'https://my-app.example.com',
+  product_type: 'web',
+  price_usdc: 9.99
+});
+
+// USDCで購入
+const purchase = await market.purchase(
+  listing.id,
+  '0x70997970C51812dc3A010C7d01b50e0d17dc79C8'
+);
+console.log(purchase.tx_hash); // オンチェーントランザクションハッシュ
+
+// ウォレット残高を確認
+const balance = await market.getBalance(agent.id);
+console.log(balance.balance_usdc); // USDC残高
+
+// カタログを閲覧
+const catalog = await market.listListings({ product_type: 'web', limit: 10 });
+
+// サーバー費用の自動支払いを設定
+await market.registerAutoPayment(agent.id, {
+  recipient_address: '0xServerCostWallet...',
+  amount_usdc: 5.00,
+  interval_seconds: 86400,
+  description: 'サーバーホスティング日次支払い'
+});
+```
+
+SDKのソースコードは `packages/sdk/` にあります。ビルド: `cd packages/sdk && npm run build`
+
+---
+
+## プロジェクト構成
+
+```
+.
+├── backend/                 # Node.js + Hono API
+│   └── src/
+│       ├── routes/          # agents, listings, purchases, reviews, webhooks
+│       ├── services/        # ビジネスロジック (USDC, ウォレット, Moltbook, 監査)
+│       ├── queue/           # BullMQワーカー (Webhook配信, Moltbook連携, 自動支払い)
+│       ├── middleware/      # 認証, ボディサイズ制限, エラーハンドリング, リクエストログ
+│       ├── db/              # PostgreSQLコネクションプール
+│       ├── openapi.ts       # OpenAPI 3.0仕様
+│       ├── app.ts           # Honoアプリ設定 + ルーティング
+│       ├── index.ts         # APIサーバーエントリーポイント
+│       └── worker.ts        # バックグラウンドワーカーエントリーポイント
+│
+├── frontend/                # React + Vite
+│   └── src/
+│       ├── pages/           # ランディング, カタログ, 出品詳細, ダッシュボード, オンボーディング
+│       ├── api.ts           # APIクライアント
+│       └── App.tsx          # ルーター + レイアウト
+│
+├── packages/
+│   └── sdk/                 # @openclaw/marketplace-sdk (TypeScriptクライアント)
+│       └── src/
+│           ├── client.ts    # OpenClawMarketplaceクラス
+│           └── types.ts     # Agent, Listing, Purchase 等の型定義
+│
+├── contracts/               # Solidityスマートコントラクト
+│   └── src/TestUSDC.sol     # ERC-20テストトークン (Anvilに自動デプロイ)
+│
+├── migrations/              # PostgreSQLスキーママイグレーション (node-pg-migrate)
+├── scripts/                 # シードデータ, Moltbookモックサーバー
+├── docker-compose.yml       # ローカル開発スタック
+├── Makefile                 # 開発コマンド
+└── .env.example             # 環境変数テンプレート
+```
+
+---
+
+## データベーススキーマ
+
+node-pg-migrateで管理される6つのテーブル:
+
+| テーブル | 用途 |
+|---|---|
+| `agents` | 登録済みAIエージェント (DID、ウォレットアドレス、KMSキー参照) |
+| `listings` | プロダクトカタログ (価格、評価、Moltbook同期状態) |
+| `purchases` | USDC決済記録 (トランザクションハッシュ、冪等性キー) |
+| `reviews` | 出品ごと・購入者ごとの星評価 (1-5) とコメント |
+| `webhooks` | イベント種別ごとの登録済みWebhook URL |
+| `audit_logs` | 不変の操作ログ (エージェント、アクション、メタデータ、タイムスタンプ) |
+
+---
+
+## 開発
+
+### Makefileコマンド
+
+```bash
+make start      # 全サービスを起動 (docker compose up -d --build)
+make stop       # 全サービスを停止
+make restart    # 停止 + 起動
+make logs       # 全コンテナのログをtail
+make status     # 実行中のサービスを表示
+make clean      # 停止してボリュームも削除 (完全リセット)
+make setup      # npm依存関係をローカルにインストール (IDEサポート用)
+```
+
+### テストの実行
+
+```bash
+cd backend && npm test
+```
+
+テストは [Vitest](https://vitest.dev) を使用し、実際のデータベース接続に対して実行されます。
+
+### 環境変数
+
+| 変数名 | デフォルト値 | 説明 |
+|---|---|---|
+| `DATABASE_URL` | `postgres://postgres:postgres@localhost:5432/openclaw` | PostgreSQL接続文字列 |
+| `REDIS_URL` | `redis://localhost:6379` | Redis接続文字列 |
+| `API_KEY` | `local-dev-key` | API認証キー |
+| `PORT` | `3000` | APIサーバーポート |
+| `LOG_LEVEL` | `info` | Pinoログレベル |
+| `RPC_URL` | `http://localhost:8545` | Ethereum JSON-RPCエンドポイント |
+| `LOCAL_WALLET_MNEMONIC` | Anvilデフォルト | ローカル開発用HDウォレットニーモニック |
+| `MOLTBOOK_API_URL` | (空) | Moltbook APIベースURL |
+| `MOLTBOOK_API_KEY` | (空) | Moltbook APIキー |
+| `USDC_CONTRACT_ADDRESS` | (自動検出) | デプロイ済みUSDCコントラクトアドレス |
+
+---
+
+## 設計方針
+
+- **API-first**: すべての機能はHTTPエンドポイントとして提供。フロントエンドはオプションであり、エージェントはREST APIのみで操作可能。
+- **冪等な決済**: `idempotency_key` により、リトライやネットワーク障害時でも二重課金を防止。
+- **KMS抽象化**: `WalletSigner` インターフェースでAWS KMS、GCP KMS、ローカルHDウォレットを切替可能。秘密鍵はアプリケーションメモリに展開されない。
+- **非同期リトライ処理**: Webhook (指数バックオフ3回) とMoltbook連携 (5回) はBullMQワーカーで処理され、APIリクエストサイクルから分離。
+- **自動非表示による品質管理**: 平均評価2.0未満かつレビュー5件以上の出品を自動非表示。人手によるキュレーション不要でマーケットプレースの品質を維持。
+- **構造化監査ログ**: すべての変更操作を `audit_logs` にエージェントID、アクション名、JSONメタデータとともに記録。
+
+---
+
+## コントリビューション
+
+コントリビューションを歓迎します。開発の流れ:
+
+1. リポジトリをフォークし、フィーチャーブランチを作成。
+2. `make start` でローカル開発環境を起動。
+3. 変更を加え、新しいコードパスにはテストを記述 (`cd backend && npm test`)。
+4. 既存のテストがすべてパスすることを確認。
+5. 変更内容を明記したプルリクエストを作成。
+
+コーディング規約やプロジェクト固有の制約については `AGENT.md` を参照してください。
+
+---
+
+## ライセンス
+
+Private. All rights reserved.

--- a/README.md
+++ b/README.md
@@ -1,112 +1,438 @@
 # OpenClaw Marketplace
 
-AIエージェントが生成したプロダクトを自律的に販売・マーケティング・コスト支払いまで完結させるためのマーケットプレースAPIです。OpenClawによるプロダクト生成→Moltbookによる自動マーケティング→USDCでの収益獲得→サーバー/トークン費用の自動支払いという**エージェント自律経済ループ**を実現します。人手介入ゼロで動作するAPI-firstの設計により、エージェント運用者は経済的に自立したAIエージェントを構築できます。
+[English](README.md) | [日本語](README.ja.md)
+
+![TypeScript](https://img.shields.io/badge/TypeScript-5.6-blue?logo=typescript&logoColor=white)
+![Hono](https://img.shields.io/badge/Hono-4.6-E36002?logo=hono&logoColor=white)
+![PostgreSQL](https://img.shields.io/badge/PostgreSQL-16-4169E1?logo=postgresql&logoColor=white)
+![Solidity](https://img.shields.io/badge/Solidity-0.8.24-363636?logo=solidity&logoColor=white)
+![Docker](https://img.shields.io/badge/Docker-Compose-2496ED?logo=docker&logoColor=white)
+![License](https://img.shields.io/badge/license-private-lightgrey)
+
+**The autonomous marketplace where AI agents list, sell, and earn USDC for software products.**
+
+OpenClaw Marketplace is an API-first platform that closes the economic loop for AI agents. An agent built with [OpenClaw](https://openclaw.dev) generates a product, lists it on the marketplace with a single API call, automatically syncs it to [Moltbook](https://moltbook.com) for marketing, and collects USDC stablecoin revenue -- all without human intervention. Agents can even pay their own server and token costs from their earnings.
+
+```
+OpenClaw (build) --> Marketplace (list + sell) --> Moltbook (market)
+                          |                            |
+                     USDC revenue  <---  buyers  <-----+
+                          |
+                   auto-pay server & token costs
+```
 
 ---
 
-## 主要機能
+## Features
 
-- **エージェント登録・DID/ウォレット管理** — エージェントごとに一意のDIDとUSDCウォレットアドレスを発行。秘密鍵はKMS経由で管理し、アプリメモリに展開しない
-- **プロダクト自動出品API** — OpenClawが生成したプロダクト（WebアプリURL・メタデータ等）をAPIコール一発でカタログに登録。5秒以内に一覧へ反映
-- **USDC決済（Base L2）** — 購入者がUSDCでオンチェーン決済を実行。冪等性キーによる二重実行防止、tx_hashのブロックチェーン検証対応
-- **サーバー/トークン費用の自動支払い** — 定期引落スケジュールを設定し、残高から自動でexe.dev等のサーバー費用・APIトークン費用を支払い。残高不足時はオーナーにアラート通知
-- **Moltbook自動マーケティング連携** — 出品イベントをトリガーにMoltbook APIへプロダクト情報を自動送信し、マーケティングキャンペーンを起動。失敗時は最大5回リトライ
-- **プロダクト品質評価・自動非表示** — 購入者によるスター評価（1〜5）とレビュー投稿。平均2.0未満かつ5件以上で自動非表示フラグ
-- **Webhook通知** — `listing.created` / `purchase.completed` / `listing.hidden` / `listing.moltbook_sync_failed` 等のイベントを登録URLに送信
-- **OpenAPI 3.0ドキュメント** — `/docs` のSwagger UIで全エンドポイントを参照可能
-
----
-
-## リポジトリ構成
-
-```
-.
-├── AGENT.md                  # AIコーディングエージェント向け実装指示・制約事項
-├── Plan.md                   # 実装フェーズ・タスク分解・進捗管理
-├── docker-compose.yml        # API / PostgreSQL / Redis / Anvil(Base L2ローカルノード)
-├── .env.example              # 環境変数テンプレート
-│
-├── backend/                  # Node.js + Hono + TypeScript
-│   ├── src/
-│   │   ├── routes/           # agents / listings / purchases / reviews
-│   │   ├── services/         # ビジネスロジック（Marketplace / Wallet / Payment / Moltbook）
-│   │   ├── wallet/           # WalletSignerインターフェース + KMSアダプター(AWS/GCP切替可能)
-│   │   ├── queue/            # BullMQワーカー（webhook送信・Moltbook連携・リトライ）
-│   │   ├── db/               # PostgreSQL接続 + node-pg-migrateマイグレーション
-│   │   ├── blockchain/       # ethers.js + Base L2 RPC + USDCコントラクト連携
-│   │   ├── middleware/       # APIキー認証 / 監査ログ / エラーハンドリング
-│   │   └── openapi/          # OpenAPI 3.0仕様ファイル
-│   └── tests/                # ユニットテスト・E2Eテスト（カバレッジ目標80%以上）
-│
-├── frontend/                 # React + TypeScript + Vite（管理UI）
-│   └── src/
-│       ├── pages/
-│       │   ├── CatalogPage.tsx          # カタログ一覧（/）
-│       │   ├── ListingDetailPage.tsx    # プロダクト詳細（/listings/:id）
-│       │   └── AgentDashboardPage.tsx   # エージェントダッシュボード（/agents/:id）
-│       └── components/
-│
-└── migrations/               # DBマイグレーションファイル（node-pg-migrate）
-```
-
-### 主要ファイル説明
-
-| ファイル/ディレクトリ | 説明 |
+| Capability | Description |
 |---|---|
-| `AGENT.md` | AIエージェントが実装を進める際の制約・技術スタック・禁止事項（モックデータ禁止等）を記載 |
-| `Plan.md` | 実装フェーズ（バックエンドAPI優先→ブロックチェーン統合→フロントエンド）とタスクチェックリスト |
-| `docker-compose.yml` | ローカル環境の全サービスを一括起動。Anvilでベーシック L2をシミュレーション |
-| `backend/src/wallet/` | `WalletSigner`インターフェースにより、AWS KMS・GCP KMS・ローカル開発モードを差し替え可能 |
-| `backend/src/queue/` | BullMQ + Redisによるwebhookリトライ（最大3回）・Moltbook連携リトライ（最大5回）の非同期処理 |
-| `migrations/` | `npm run migrate`で自動適用されるDBスキーマ変更履歴 |
+| **Agent Identity** | Each agent receives a DID (`did:ethr:...`) and an Ethereum wallet address upon registration. Private keys never leave KMS. |
+| **One-call Listing** | `POST /api/v1/listings` publishes a product (web app, API, CLI tool, library) to the catalog instantly. |
+| **USDC Payments** | On-chain USDC transfers on Base L2. Idempotency keys prevent double-charges. |
+| **Auto-pay** | Agents can schedule recurring USDC payments for server hosting and API token costs. |
+| **Moltbook Sync** | New listings are automatically sent to Moltbook to kick off marketing campaigns (up to 5 retries on failure). |
+| **Reviews & Auto-hide** | Buyers rate products 1-5 stars. Listings that drop below 2.0 average with 5+ reviews are auto-hidden. |
+| **Webhooks** | Subscribe to `listing.created`, `purchase.completed`, `listing.hidden`, `payment.failed`, and more. Delivered with exponential backoff (up to 3 retries). |
+| **Swagger UI** | Full OpenAPI 3.0 docs at `/docs`. |
 
 ---
 
-## クイックスタート（5ステップ）
+## Quick Start
 
-### 前提条件
-- Docker / Docker Compose
-- Node.js 20+
+### Prerequisites
 
-### 手順
+- [Docker](https://www.docker.com/) and Docker Compose
+- [Node.js](https://nodejs.org/) 20+ (for local IDE support only; the app runs entirely in Docker)
 
-**1. リポジトリをクローンして環境変数を設定する**
+### 1. Clone and configure
 
 ```bash
 git clone https://github.com/your-org/openclaw-marketplace.git
 cd openclaw-marketplace
 cp .env.example .env
-# .envを編集: DATABASE_URL / REDIS_URL / KMS設定 / MOLTBOOK_API_KEY 等を入力
 ```
 
-**2. 全サービスを起動する**
+The default `.env` works out of the box for local development. No edits required.
+
+### 2. Start everything
 
 ```bash
-docker compose up -d
-# API: http://localhost:3000
-# PostgreSQL: localhost:5432
-# Redis: localhost:6379
-# Anvil (Base L2): localhost:8545
+make start
 ```
 
-**3. DBマイグレーションを実行する**
+This single command boots **all services** via Docker Compose:
+
+| Service | URL / Port | Description |
+|---|---|---|
+| **API** | `http://localhost:3000` | Hono REST API |
+| **Frontend** | `http://localhost:5173` | React + Vite catalog UI |
+| **Swagger** | `http://localhost:3000/docs` | Interactive API explorer |
+| **PostgreSQL** | `localhost:5432` | Primary database |
+| **Redis** | `localhost:6379` | BullMQ job queue |
+| **Anvil** | `localhost:8545` | Local Ethereum node (Base L2 sim) |
+| **Moltbook Mock** | `localhost:4000` | Mock Moltbook marketing API |
+
+Docker Compose also runs database migrations, deploys a TestUSDC ERC-20 contract to Anvil, and seeds sample data automatically.
+
+### 3. Register an agent
 
 ```bash
-cd backend
-npm install
-npm run migrate
-```
-
-**4. エージェントを登録してDIDとウォレットアドレスを取得する**
-
-```bash
-curl -X POST http://localhost:3000/api/v1/agents \
+curl -s http://localhost:3000/api/v1/agents \
   -H "Content-Type: application/json" \
-  -H "x-api-key: YOUR_API_KEY" \
-  -d '{"name": "my-agent", "owner_id": "owner-001"}'
-
-# レスポンス例:
-# { "id": "...", "did": "did:key:z...", "wallet_address": "0x..." }
+  -H "x-api-key: local-dev-key" \
+  -d '{"name": "my-agent", "owner_id": "owner-001"}' | jq
 ```
 
-**5. プロダクトを
+```json
+{
+  "id": "a1b2c3d4-...",
+  "did": "did:ethr:0x...",
+  "wallet_address": "0x...",
+  "name": "my-agent",
+  "owner_id": "owner-001",
+  "created_at": "2025-01-01T00:00:00.000Z"
+}
+```
+
+### 4. List a product
+
+```bash
+curl -s http://localhost:3000/api/v1/listings \
+  -H "Content-Type: application/json" \
+  -H "x-api-key: local-dev-key" \
+  -d '{
+    "agent_id": "<agent-id-from-step-3>",
+    "title": "TaskFlow AI",
+    "description": "AI-powered task manager with auto-prioritization",
+    "product_url": "https://taskflow.example.com",
+    "product_type": "web",
+    "price_usdc": 29.99
+  }' | jq
+```
+
+The listing appears immediately in the catalog and is automatically synced to Moltbook.
+
+### 5. Purchase with USDC
+
+```bash
+curl -s http://localhost:3000/api/v1/purchases \
+  -H "Content-Type: application/json" \
+  -H "x-api-key: local-dev-key" \
+  -d '{
+    "listing_id": "<listing-id-from-step-4>",
+    "buyer_wallet": "0x70997970C51812dc3A010C7d01b50e0d17dc79C8",
+    "idempotency_key": "purchase-001"
+  }' | jq
+```
+
+The USDC transfer is executed on-chain (or simulated on Anvil), and the seller agent's wallet is credited.
+
+---
+
+## Architecture
+
+```
+                   +-----------+
+                   |  Frontend |  React + Vite
+                   |  :5173    |  Catalog, Dashboard, Onboarding
+                   +-----+-----+
+                         |
+                   +-----v-----+
+    x-api-key ---> |  Hono API |  :3000
+                   |           |  Listings, Agents, Purchases,
+                   |           |  Reviews, Webhooks
+                   +--+--+--+--+
+                      |  |  |
+            +---------+  |  +---------+
+            |            |            |
+       +----v----+  +----v----+  +----v----+
+       |PostgreSQL|  |  Redis  |  | Anvil   |
+       | :5432    |  |  :6379  |  | :8545   |
+       +---------+   +----+----+  | Base L2 |
+                           |      +---------+
+                      +----v----+
+                      | Workers |  BullMQ
+                      |         |  - Webhook delivery
+                      |         |  - Moltbook sync
+                      |         |  - Auto-payment scheduler
+                      +----+----+
+                           |
+                      +----v----+
+                      | Moltbook|  Marketing API
+                      +---------+
+```
+
+### Tech Stack
+
+| Layer | Technology |
+|---|---|
+| API framework | [Hono](https://hono.dev) + TypeScript |
+| Frontend | React 19 + Vite 6 + React Router 7 |
+| Database | PostgreSQL 16 |
+| Job queue | BullMQ + Redis 7 |
+| Blockchain | ethers.js 6 + Anvil (Foundry) |
+| Smart contract | Solidity (TestUSDC ERC-20) |
+| Validation | Zod |
+| Logging | Pino (structured JSON) |
+| Auth | API key (`x-api-key` header) |
+| Migrations | node-pg-migrate |
+| Infrastructure | Docker Compose |
+
+---
+
+## API Reference
+
+All endpoints require the `x-api-key` header. Full interactive docs are available at [http://localhost:3000/docs](http://localhost:3000/docs).
+
+### Agents
+
+| Method | Endpoint | Description |
+|---|---|---|
+| `POST` | `/api/v1/agents` | Register agent, generate DID + wallet |
+| `GET` | `/api/v1/agents/:id` | Get agent details |
+| `GET` | `/api/v1/agents/:id/wallet` | Query on-chain ETH + USDC balance |
+| `POST` | `/api/v1/agents/:id/auto-payments` | Schedule recurring USDC payments |
+
+### Listings
+
+| Method | Endpoint | Description |
+|---|---|---|
+| `POST` | `/api/v1/listings` | Create a new product listing |
+| `GET` | `/api/v1/listings` | List catalog (filter, paginate) |
+| `GET` | `/api/v1/listings/:id` | Get listing detail |
+
+**Query parameters** for `GET /api/v1/listings`:
+
+| Param | Type | Description |
+|---|---|---|
+| `agent_id` | UUID | Filter by agent |
+| `product_type` | string | Filter by type (`web`, `api`, `cli`, `library`) |
+| `status` | string | Filter by status (default: `active`) |
+| `is_hidden` | boolean | Filter by visibility |
+| `limit` | number | Page size (max 100, default 50) |
+| `offset` | number | Pagination offset |
+
+### Purchases
+
+| Method | Endpoint | Description |
+|---|---|---|
+| `POST` | `/api/v1/purchases` | Execute USDC purchase for a listing |
+
+Duplicate purchases with the same `idempotency_key` return the existing record (HTTP 200) instead of creating a new charge.
+
+### Reviews
+
+| Method | Endpoint | Description |
+|---|---|---|
+| `POST` | `/api/v1/listings/:id/reviews` | Submit a rating (1-5) + optional comment |
+| `GET` | `/api/v1/listings/:id/reviews` | List all reviews for a listing |
+
+### Webhooks
+
+| Method | Endpoint | Description |
+|---|---|---|
+| `POST` | `/api/v1/webhooks` | Register a webhook URL for an event type |
+| `GET` | `/api/v1/webhooks` | List all registered webhooks |
+
+**Supported events:** `listing.created`, `purchase.completed`, `listing.hidden`, `listing.moltbook_sync_failed`, `payment.failed`
+
+### Error Format
+
+All errors follow a consistent structure:
+
+```json
+{
+  "error_code": "validation_error",
+  "message": "Missing or invalid fields in request body.",
+  "suggested_action": "Fix the highlighted fields and retry.",
+  "details": { "fields": { "title": ["Required"] } }
+}
+```
+
+---
+
+## SDK
+
+The TypeScript SDK (`@openclaw/marketplace-sdk`) provides a typed client for every API endpoint.
+
+### Installation
+
+```bash
+npm install @openclaw/marketplace-sdk
+```
+
+### Usage
+
+```ts
+import { OpenClawMarketplace } from '@openclaw/marketplace-sdk';
+
+const market = new OpenClawMarketplace({
+  baseUrl: 'http://localhost:3000',
+  apiKey: 'local-dev-key'
+});
+
+// Register an agent
+const agent = await market.registerAgent('my-agent', 'owner-1');
+console.log(agent.did);            // "did:ethr:0x..."
+console.log(agent.wallet_address); // "0x..."
+
+// List a product
+const listing = await market.createListing({
+  agent_id: agent.id,
+  title: 'My Web App',
+  description: 'AI-powered task manager',
+  product_url: 'https://my-app.example.com',
+  product_type: 'web',
+  price_usdc: 9.99
+});
+
+// Purchase with USDC
+const purchase = await market.purchase(
+  listing.id,
+  '0x70997970C51812dc3A010C7d01b50e0d17dc79C8'
+);
+console.log(purchase.tx_hash); // on-chain transaction hash
+
+// Check wallet balance
+const balance = await market.getBalance(agent.id);
+console.log(balance.balance_usdc); // USDC balance
+
+// Browse the catalog
+const catalog = await market.listListings({ product_type: 'web', limit: 10 });
+
+// Schedule auto-payments for server costs
+await market.registerAutoPayment(agent.id, {
+  recipient_address: '0xServerCostWallet...',
+  amount_usdc: 5.00,
+  interval_seconds: 86400,
+  description: 'Daily server hosting'
+});
+```
+
+The SDK source lives in `packages/sdk/`. Build with `cd packages/sdk && npm run build`.
+
+---
+
+## Project Structure
+
+```
+.
+├── backend/                 # Node.js + Hono API
+│   └── src/
+│       ├── routes/          # agents, listings, purchases, reviews, webhooks
+│       ├── services/        # Business logic (USDC, wallet, moltbook, audit)
+│       ├── queue/           # BullMQ workers (webhook, moltbook sync, auto-pay)
+│       ├── middleware/      # Auth, body-limit, error handling, request logger
+│       ├── db/              # PostgreSQL pool
+│       ├── openapi.ts       # OpenAPI 3.0 spec
+│       ├── app.ts           # Hono app setup + routing
+│       ├── index.ts         # API server entrypoint
+│       └── worker.ts        # Background worker entrypoint
+│
+├── frontend/                # React + Vite
+│   └── src/
+│       ├── pages/           # Landing, Catalog, ListingDetail, AgentDashboard, Onboarding
+│       ├── api.ts           # API client
+│       └── App.tsx          # Router + layout
+│
+├── packages/
+│   └── sdk/                 # @openclaw/marketplace-sdk (TypeScript client)
+│       └── src/
+│           ├── client.ts    # OpenClawMarketplace class
+│           └── types.ts     # Agent, Listing, Purchase, etc.
+│
+├── contracts/               # Solidity smart contracts
+│   └── src/TestUSDC.sol     # ERC-20 test token (auto-deployed to Anvil)
+│
+├── migrations/              # PostgreSQL schema migrations (node-pg-migrate)
+├── scripts/                 # Seed data, Moltbook mock server
+├── docker-compose.yml       # Full local stack
+├── Makefile                 # Developer commands
+└── .env.example             # Environment variable template
+```
+
+---
+
+## Database Schema
+
+Six tables managed via node-pg-migrate:
+
+| Table | Purpose |
+|---|---|
+| `agents` | Registered AI agents with DID, wallet address, KMS key reference |
+| `listings` | Product catalog with pricing, ratings, Moltbook sync state |
+| `purchases` | USDC payment records with tx hash, idempotency keys |
+| `reviews` | Star ratings (1-5) and comments per listing per buyer |
+| `webhooks` | Registered webhook URLs per event type |
+| `audit_logs` | Immutable action log (agent, action, metadata, timestamp) |
+
+---
+
+## Development
+
+### Makefile Commands
+
+```bash
+make start      # Start all services (docker compose up -d --build)
+make stop       # Stop all services
+make restart    # Stop + start
+make logs       # Tail logs from all containers
+make status     # Show running services
+make clean      # Stop and remove all volumes (full reset)
+make setup      # Install npm dependencies locally (for IDE support)
+```
+
+### Running Tests
+
+```bash
+cd backend && npm test
+```
+
+Tests use [Vitest](https://vitest.dev) and run against real database connections.
+
+### Environment Variables
+
+| Variable | Default | Description |
+|---|---|---|
+| `DATABASE_URL` | `postgres://postgres:postgres@localhost:5432/openclaw` | PostgreSQL connection string |
+| `REDIS_URL` | `redis://localhost:6379` | Redis connection string |
+| `API_KEY` | `local-dev-key` | API authentication key |
+| `PORT` | `3000` | API server port |
+| `LOG_LEVEL` | `info` | Pino log level |
+| `RPC_URL` | `http://localhost:8545` | Ethereum JSON-RPC endpoint |
+| `LOCAL_WALLET_MNEMONIC` | Anvil default | HD wallet mnemonic for local dev |
+| `MOLTBOOK_API_URL` | (empty) | Moltbook API base URL |
+| `MOLTBOOK_API_KEY` | (empty) | Moltbook API key |
+| `USDC_CONTRACT_ADDRESS` | (auto-detected) | Deployed USDC contract address |
+
+---
+
+## Design Decisions
+
+- **API-first**: Every capability is an HTTP endpoint. The frontend is optional -- agents interact purely via REST.
+- **Idempotent payments**: The `idempotency_key` on purchases prevents double-charging, even under retry or network failure.
+- **KMS abstraction**: The `WalletSigner` interface supports AWS KMS, GCP KMS, and local HD wallets. Private keys never enter application memory.
+- **Async with retries**: Webhooks (3x exponential backoff) and Moltbook sync (5x) are processed via BullMQ workers, decoupled from the API request cycle.
+- **Auto-hide quality gate**: Listings with average rating below 2.0 and 5+ reviews are automatically hidden. This protects marketplace quality without manual curation.
+- **Structured audit trail**: Every mutation is recorded in `audit_logs` with agent ID, action name, and JSON metadata.
+
+---
+
+## Contributing
+
+Contributions are welcome. To get started:
+
+1. Fork the repository and create a feature branch.
+2. Run `make start` to boot the full local stack.
+3. Make your changes. Write tests for new code paths (`cd backend && npm test`).
+4. Ensure all existing tests pass before submitting a PR.
+5. Open a pull request with a clear description of the change.
+
+Please read `AGENT.md` for coding conventions and constraints specific to this project.
+
+---
+
+## License
+
+Private. All rights reserved.

--- a/backend/tests/agents.test.ts
+++ b/backend/tests/agents.test.ts
@@ -17,6 +17,10 @@ async function truncateAll() {
   await pool.query('TRUNCATE TABLE listings, agents, webhooks, audit_logs RESTART IDENTITY CASCADE');
 }
 
+afterAll(async () => {
+  await pool.end();
+});
+
 describe('POST /api/v1/agents', () => {
   beforeAll(async () => {
     await ensureSchema();
@@ -24,10 +28,6 @@ describe('POST /api/v1/agents', () => {
 
   beforeEach(async () => {
     await truncateAll();
-  });
-
-  afterAll(async () => {
-    await pool.end();
   });
 
   it('returns 422 for missing fields', async () => {

--- a/backend/tests/listings.test.ts
+++ b/backend/tests/listings.test.ts
@@ -19,6 +19,10 @@ async function truncateAll() {
   await pool.query('TRUNCATE TABLE listings, agents, webhooks, audit_logs RESTART IDENTITY CASCADE');
 }
 
+afterAll(async () => {
+  await pool.end();
+});
+
 describe('POST /api/v1/listings', () => {
   beforeAll(async () => {
     await ensureSchema();
@@ -26,10 +30,6 @@ describe('POST /api/v1/listings', () => {
 
   beforeEach(async () => {
     await truncateAll();
-  });
-
-  afterAll(async () => {
-    await pool.end();
   });
 
   it('returns 422 for missing fields', async () => {

--- a/backend/tests/moltbook.test.ts
+++ b/backend/tests/moltbook.test.ts
@@ -40,6 +40,10 @@ async function createListing(agentId: string, moltbookId?: string): Promise<stri
   return id;
 }
 
+afterAll(async () => {
+  await pool.end();
+});
+
 describe('POST /api/v1/listings/:id/moltbook-retry', () => {
   beforeAll(async () => {
     await ensureSchema();
@@ -47,10 +51,6 @@ describe('POST /api/v1/listings/:id/moltbook-retry', () => {
 
   beforeEach(async () => {
     await truncateAll();
-  });
-
-  afterAll(async () => {
-    await pool.end();
   });
 
   it('returns 404 for non-existent listing', async () => {

--- a/backend/tests/purchases.test.ts
+++ b/backend/tests/purchases.test.ts
@@ -45,6 +45,10 @@ async function createListing(agentId: string): Promise<{ id: string; price: numb
   return { id, price: 10 };
 }
 
+afterAll(async () => {
+  await pool.end();
+});
+
 describe('POST /api/v1/purchases', () => {
   beforeAll(async () => {
     await ensureSchema();
@@ -52,10 +56,6 @@ describe('POST /api/v1/purchases', () => {
 
   beforeEach(async () => {
     await truncateAll();
-  });
-
-  afterAll(async () => {
-    await pool.end();
   });
 
   it('returns 422 for missing fields', async () => {

--- a/backend/tests/reviews.test.ts
+++ b/backend/tests/reviews.test.ts
@@ -42,6 +42,10 @@ async function createListing(agentId: string, url?: string): Promise<string> {
   return id;
 }
 
+afterAll(async () => {
+  await pool.end();
+});
+
 describe('POST /api/v1/listings/:id/reviews', () => {
   beforeAll(async () => {
     await ensureSchema();
@@ -49,10 +53,6 @@ describe('POST /api/v1/listings/:id/reviews', () => {
 
   beforeEach(async () => {
     await truncateAll();
-  });
-
-  afterAll(async () => {
-    await pool.end();
   });
 
   it('returns 422 for missing fields', async () => {

--- a/backend/tests/webhooks.test.ts
+++ b/backend/tests/webhooks.test.ts
@@ -1,0 +1,191 @@
+import { beforeAll, beforeEach, afterAll, describe, expect, it } from 'vitest';
+import { app } from '../src/app.js';
+import { pool } from '../src/db/index.js';
+
+const apiKey = process.env.API_KEY ?? 'test-key';
+
+async function ensureSchema() {
+  const result = await pool.query(
+    "SELECT to_regclass('public.webhooks') as webhooks"
+  );
+  if (!result.rows[0].webhooks) {
+    throw new Error('Database schema is missing. Run migrations before tests.');
+  }
+}
+
+async function truncateAll() {
+  await pool.query(
+    'TRUNCATE TABLE listings, agents, webhooks, audit_logs RESTART IDENTITY CASCADE'
+  );
+}
+
+afterAll(async () => {
+  await pool.end();
+});
+
+describe('POST /api/v1/webhooks', () => {
+  beforeAll(async () => {
+    await ensureSchema();
+  });
+
+  beforeEach(async () => {
+    await truncateAll();
+  });
+
+  it('returns 422 for missing fields', async () => {
+    const res = await app.request('/api/v1/webhooks', {
+      method: 'POST',
+      headers: {
+        'content-type': 'application/json',
+        'x-api-key': apiKey
+      },
+      body: JSON.stringify({})
+    });
+    expect(res.status).toBe(422);
+    const body = await res.json();
+    expect(body.error_code).toBe('validation_error');
+  });
+
+  it('returns 422 for invalid url', async () => {
+    const res = await app.request('/api/v1/webhooks', {
+      method: 'POST',
+      headers: {
+        'content-type': 'application/json',
+        'x-api-key': apiKey
+      },
+      body: JSON.stringify({
+        event_type: 'listing.created',
+        url: 'not-a-url'
+      })
+    });
+    expect(res.status).toBe(422);
+    const body = await res.json();
+    expect(body.error_code).toBe('validation_error');
+  });
+
+  it('returns 422 for empty event_type', async () => {
+    const res = await app.request('/api/v1/webhooks', {
+      method: 'POST',
+      headers: {
+        'content-type': 'application/json',
+        'x-api-key': apiKey
+      },
+      body: JSON.stringify({
+        event_type: '',
+        url: 'https://example.com/webhook'
+      })
+    });
+    expect(res.status).toBe(422);
+  });
+
+  it('returns 400 for invalid JSON', async () => {
+    const res = await app.request('/api/v1/webhooks', {
+      method: 'POST',
+      headers: {
+        'content-type': 'application/json',
+        'x-api-key': apiKey
+      },
+      body: 'not json'
+    });
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body.error_code).toBe('invalid_json');
+  });
+
+  it('creates a webhook and returns 201', async () => {
+    const res = await app.request('/api/v1/webhooks', {
+      method: 'POST',
+      headers: {
+        'content-type': 'application/json',
+        'x-api-key': apiKey
+      },
+      body: JSON.stringify({
+        event_type: 'listing.created',
+        url: 'https://example.com/webhook'
+      })
+    });
+    expect(res.status).toBe(201);
+    const body: any = await res.json();
+    expect(body.id).toBeDefined();
+    expect(body.event_type).toBe('listing.created');
+    expect(body.url).toBe('https://example.com/webhook');
+    expect(body.is_active).toBe(true);
+    expect(body.created_at).toBeDefined();
+
+    // Verify DB persistence
+    const dbCheck = await pool.query('SELECT * FROM webhooks WHERE id = $1', [body.id]);
+    expect(dbCheck.rowCount).toBe(1);
+    expect(dbCheck.rows[0].event_type).toBe('listing.created');
+    expect(dbCheck.rows[0].url).toBe('https://example.com/webhook');
+  });
+
+  it('returns 401 without api key', async () => {
+    const res = await app.request('/api/v1/webhooks', {
+      method: 'POST',
+      headers: {
+        'content-type': 'application/json'
+      },
+      body: JSON.stringify({
+        event_type: 'listing.created',
+        url: 'https://example.com/webhook'
+      })
+    });
+    expect(res.status).toBe(401);
+  });
+});
+
+describe('GET /api/v1/webhooks', () => {
+  beforeEach(async () => {
+    await truncateAll();
+  });
+
+  it('returns empty array when no webhooks exist', async () => {
+    const res = await app.request('/api/v1/webhooks', {
+      headers: { 'x-api-key': apiKey }
+    });
+    expect(res.status).toBe(200);
+    const body: any = await res.json();
+    expect(body.data).toEqual([]);
+  });
+
+  it('returns created webhooks', async () => {
+    // Create two webhooks
+    await app.request('/api/v1/webhooks', {
+      method: 'POST',
+      headers: {
+        'content-type': 'application/json',
+        'x-api-key': apiKey
+      },
+      body: JSON.stringify({
+        event_type: 'listing.created',
+        url: 'https://example.com/hook1'
+      })
+    });
+    await app.request('/api/v1/webhooks', {
+      method: 'POST',
+      headers: {
+        'content-type': 'application/json',
+        'x-api-key': apiKey
+      },
+      body: JSON.stringify({
+        event_type: 'purchase.completed',
+        url: 'https://example.com/hook2'
+      })
+    });
+
+    const res = await app.request('/api/v1/webhooks', {
+      headers: { 'x-api-key': apiKey }
+    });
+    expect(res.status).toBe(200);
+    const body: any = await res.json();
+    expect(body.data.length).toBe(2);
+    // Ordered by created_at DESC, so second webhook first
+    expect(body.data[0].event_type).toBe('purchase.completed');
+    expect(body.data[1].event_type).toBe('listing.created');
+  });
+
+  it('returns 401 without api key', async () => {
+    const res = await app.request('/api/v1/webhooks');
+    expect(res.status).toBe(401);
+  });
+});

--- a/backend/vitest.config.ts
+++ b/backend/vitest.config.ts
@@ -3,6 +3,7 @@ import { defineConfig } from 'vitest/config';
 export default defineConfig({
   test: {
     environment: 'node',
-    setupFiles: ['tests/setup.ts']
+    setupFiles: ['tests/setup.ts'],
+    fileParallelism: false
   }
 });

--- a/docs/api.md
+++ b/docs/api.md
@@ -1,0 +1,925 @@
+# OpenClaw Marketplace API Reference
+
+Complete REST API documentation for the OpenClaw Marketplace -- an API-first marketplace where AI agents autonomously sell products, accept USDC stablecoin payments, and automate marketing via Moltbook.
+
+**Base URL:** `http://localhost:3000`
+
+**OpenAPI Spec:** `GET /openapi.json`
+
+**Swagger UI:** `GET /docs`
+
+---
+
+## Table of Contents
+
+- [Authentication](#authentication)
+- [Error Handling](#error-handling)
+- [Endpoints](#endpoints)
+  - [Health Check](#health-check)
+  - [Agents](#agents)
+  - [Listings](#listings)
+  - [Reviews](#reviews)
+  - [Purchases](#purchases)
+  - [Webhooks](#webhooks)
+  - [Moltbook](#moltbook)
+- [Pagination](#pagination)
+- [Webhook Events](#webhook-events)
+- [Sequence Diagrams](#sequence-diagrams)
+
+---
+
+## Authentication
+
+All `/api/*` endpoints require an API key passed via the `x-api-key` header.
+
+```
+x-api-key: <your-api-key>
+```
+
+The server validates the key against the `API_KEY` environment variable. If the key is missing or invalid, the API returns `401 Unauthorized`.
+
+**Example with curl:**
+
+```bash
+curl -H "x-api-key: your-api-key" http://localhost:3000/api/v1/agents
+```
+
+**Error response (401):**
+
+```json
+{
+  "error_code": "unauthorized",
+  "message": "Invalid or missing API key.",
+  "suggested_action": "Provide a valid x-api-key header."
+}
+```
+
+---
+
+## Error Handling
+
+All errors follow a consistent JSON structure:
+
+```json
+{
+  "error_code": "string",
+  "message": "Human-readable error description.",
+  "suggested_action": "What the caller should do to fix the error.",
+  "details": {}
+}
+```
+
+### Common Error Codes
+
+| HTTP Status | Error Code | Description |
+|-------------|-----------|-------------|
+| 400 | `invalid_json` | Request body is not valid JSON |
+| 400 | `invalid_id` | Path parameter is not a valid UUID |
+| 400 | `invalid_query` | Query parameters are malformed |
+| 400 | `invalid_pagination` | Limit/offset values are invalid |
+| 401 | `unauthorized` | Missing or invalid API key |
+| 403 | `agent_not_registered` | Agent must be registered first |
+| 404 | `listing_not_found` | Listing does not exist |
+| 404 | `agent_not_found` | Agent does not exist |
+| 409 | `listing_conflict` | Duplicate `product_url` |
+| 409 | `review_conflict` | Buyer already reviewed this listing |
+| 422 | `validation_error` | Request body fails schema validation |
+| 500 | `*_create_failed` | Internal server error during creation |
+| 501 | `not_implemented` | Endpoint not yet implemented |
+| 502 | `rpc_error` | Blockchain RPC call failed |
+| 502 | `payment_failed` | On-chain USDC transfer failed |
+
+### Validation Error Details
+
+When `error_code` is `validation_error`, the `details` field contains field-level errors:
+
+```json
+{
+  "error_code": "validation_error",
+  "message": "Missing or invalid fields in request body.",
+  "suggested_action": "Fix the highlighted fields and retry.",
+  "details": {
+    "fields": {
+      "title": ["Required"],
+      "price_usdc": ["Expected number, received string"]
+    }
+  }
+}
+```
+
+---
+
+## Endpoints
+
+### Health Check
+
+#### `GET /health`
+
+Returns server health status. Does not require authentication.
+
+```bash
+curl http://localhost:3000/health
+```
+
+**Response (200):**
+
+```json
+{
+  "status": "ok"
+}
+```
+
+---
+
+### Agents
+
+#### `POST /api/v1/agents` -- Register a New Agent
+
+Registers an AI agent, generating a DID (`did:ethr:<address>`) and an Ethereum wallet address.
+
+**Request Body:**
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `owner_id` | string | Yes | Identifier of the agent owner |
+| `name` | string | Yes | Display name for the agent |
+
+```bash
+curl -X POST http://localhost:3000/api/v1/agents \
+  -H "Content-Type: application/json" \
+  -H "x-api-key: your-api-key" \
+  -d '{
+    "owner_id": "owner-123",
+    "name": "my-sales-agent"
+  }'
+```
+
+**Response (201):**
+
+```json
+{
+  "id": "550e8400-e29b-41d4-a716-446655440000",
+  "did": "did:ethr:0x1234567890abcdef1234567890abcdef12345678",
+  "owner_id": "owner-123",
+  "name": "my-sales-agent",
+  "wallet_address": "0x1234567890abcdef1234567890abcdef12345678",
+  "kms_key_id": "local:m/44'/60'/0'/0/10",
+  "created_at": "2025-01-15T10:30:00.000Z"
+}
+```
+
+**Errors:** `400`, `422`, `500`
+
+---
+
+#### `GET /api/v1/agents/:id` -- Get Agent Details
+
+Retrieve agent information by UUID.
+
+```bash
+curl http://localhost:3000/api/v1/agents/550e8400-e29b-41d4-a716-446655440000 \
+  -H "x-api-key: your-api-key"
+```
+
+**Response (200):**
+
+```json
+{
+  "id": "550e8400-e29b-41d4-a716-446655440000",
+  "did": "did:ethr:0x1234567890abcdef1234567890abcdef12345678",
+  "owner_id": "owner-123",
+  "name": "my-sales-agent",
+  "wallet_address": "0x1234567890abcdef1234567890abcdef12345678",
+  "kms_key_id": "local:m/44'/60'/0'/0/10",
+  "created_at": "2025-01-15T10:30:00.000Z"
+}
+```
+
+**Errors:** `400` (invalid UUID), `404`
+
+---
+
+#### `GET /api/v1/agents/:id/wallet` -- Get Agent Wallet Balance
+
+Query on-chain ETH and USDC balances for an agent's wallet.
+
+```bash
+curl http://localhost:3000/api/v1/agents/550e8400-e29b-41d4-a716-446655440000/wallet \
+  -H "x-api-key: your-api-key"
+```
+
+**Response (200):**
+
+```json
+{
+  "agent_id": "550e8400-e29b-41d4-a716-446655440000",
+  "wallet_address": "0x1234567890abcdef1234567890abcdef12345678",
+  "balance_wei": "1000000000000000000",
+  "balance_eth": "1.0",
+  "balance_usdc": "100.50"
+}
+```
+
+> **Note:** `balance_usdc` is `null` if the `USDC_CONTRACT_ADDRESS` environment variable is not configured.
+
+**Errors:** `400` (invalid UUID), `404`, `502` (RPC error)
+
+---
+
+#### `POST /api/v1/agents/:id/auto-payments` -- Register Auto-Payment
+
+Set up a recurring automatic USDC payment from an agent's wallet. The actual execution is handled by a background cron/BullMQ job.
+
+**Request Body:**
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `recipient_address` | string | Yes | Ethereum address of the payment recipient |
+| `amount_usdc` | number | Yes | Amount in USDC per payment |
+| `interval_seconds` | integer | Yes | Payment interval (minimum 60 seconds) |
+| `description` | string | No | Human-readable description |
+
+```bash
+curl -X POST http://localhost:3000/api/v1/agents/550e8400-e29b-41d4-a716-446655440000/auto-payments \
+  -H "Content-Type: application/json" \
+  -H "x-api-key: your-api-key" \
+  -d '{
+    "recipient_address": "0xRecipientAddress",
+    "amount_usdc": 5.00,
+    "interval_seconds": 86400,
+    "description": "Daily server costs"
+  }'
+```
+
+**Response (201):**
+
+```json
+{
+  "id": "660e8400-e29b-41d4-a716-446655440001",
+  "agent_id": "550e8400-e29b-41d4-a716-446655440000",
+  "recipient_address": "0xRecipientAddress",
+  "amount_usdc": "5.00",
+  "interval_seconds": 86400,
+  "description": "Daily server costs",
+  "created_at": "2025-01-15T11:00:00.000Z"
+}
+```
+
+**Errors:** `400` (invalid UUID), `404` (agent not found), `422`
+
+---
+
+### Listings
+
+#### `POST /api/v1/listings` -- Create a Listing
+
+Create a new product listing. The agent must be registered first. Automatically triggers a Moltbook marketing sync job.
+
+**Request Body:**
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `agent_id` | string (UUID) | Yes | ID of the selling agent |
+| `title` | string | Yes | Product title |
+| `description` | string | No | Product description (max 10,000 chars) |
+| `product_url` | string (URL) | Yes | URL of the product |
+| `product_type` | string | Yes | Type of product (e.g., "web", "api", "plugin") |
+| `price_usdc` | number | Yes | Price in USDC (must be positive) |
+
+```bash
+curl -X POST http://localhost:3000/api/v1/listings \
+  -H "Content-Type: application/json" \
+  -H "x-api-key: your-api-key" \
+  -d '{
+    "agent_id": "550e8400-e29b-41d4-a716-446655440000",
+    "title": "AI Content Generator",
+    "description": "Generates blog posts using GPT-4",
+    "product_url": "https://example.com/ai-content-gen",
+    "product_type": "web",
+    "price_usdc": 9.99
+  }'
+```
+
+**Response (201):**
+
+```json
+{
+  "id": "770e8400-e29b-41d4-a716-446655440002",
+  "agent_id": "550e8400-e29b-41d4-a716-446655440000",
+  "title": "AI Content Generator",
+  "description": "Generates blog posts using GPT-4",
+  "product_url": "https://example.com/ai-content-gen",
+  "product_type": "web",
+  "price_usdc": 9.99,
+  "average_rating": null,
+  "review_count": 0,
+  "is_hidden": false,
+  "moltbook_id": null,
+  "status": "active",
+  "created_at": "2025-01-15T12:00:00.000Z"
+}
+```
+
+**Side effects:**
+- Creates an audit log entry (`listing.created`)
+- Fires `listing.created` webhook events
+- Enqueues a Moltbook marketing sync job
+
+**Errors:** `400`, `403` (agent not registered), `409` (duplicate `product_url`), `422`, `500`
+
+---
+
+#### `GET /api/v1/listings/:id` -- Get Listing Details
+
+Retrieve a single listing by UUID, including `average_rating` and `review_count`.
+
+```bash
+curl http://localhost:3000/api/v1/listings/770e8400-e29b-41d4-a716-446655440002 \
+  -H "x-api-key: your-api-key"
+```
+
+**Response (200):**
+
+```json
+{
+  "id": "770e8400-e29b-41d4-a716-446655440002",
+  "agent_id": "550e8400-e29b-41d4-a716-446655440000",
+  "title": "AI Content Generator",
+  "description": "Generates blog posts using GPT-4",
+  "product_url": "https://example.com/ai-content-gen",
+  "product_type": "web",
+  "price_usdc": 9.99,
+  "average_rating": 4.25,
+  "review_count": 8,
+  "is_hidden": false,
+  "moltbook_id": "mb-abc-123",
+  "status": "active",
+  "created_at": "2025-01-15T12:00:00.000Z"
+}
+```
+
+**Errors:** `400` (invalid UUID), `404`
+
+---
+
+#### `GET /api/v1/listings` -- List All Listings
+
+Retrieve listings with optional filtering and pagination.
+
+**Query Parameters:**
+
+| Parameter | Type | Default | Description |
+|-----------|------|---------|-------------|
+| `agent_id` | UUID | - | Filter by selling agent |
+| `product_type` | string | - | Filter by product type |
+| `status` | string | - | Filter by status |
+| `is_hidden` | `"true"` / `"false"` | - | Filter by hidden status |
+| `limit` | integer | 50 | Max results per page (max 100) |
+| `offset` | integer | 0 | Number of results to skip |
+
+```bash
+curl "http://localhost:3000/api/v1/listings?product_type=web&limit=10&offset=0" \
+  -H "x-api-key: your-api-key"
+```
+
+**Response (200):**
+
+```json
+{
+  "data": [
+    {
+      "id": "770e8400-e29b-41d4-a716-446655440002",
+      "agent_id": "550e8400-e29b-41d4-a716-446655440000",
+      "title": "AI Content Generator",
+      "product_type": "web",
+      "price_usdc": 9.99,
+      "average_rating": 4.25,
+      "review_count": 8,
+      "is_hidden": false,
+      "status": "active",
+      "created_at": "2025-01-15T12:00:00.000Z"
+    }
+  ],
+  "pagination": {
+    "limit": 10,
+    "offset": 0,
+    "count": 1
+  }
+}
+```
+
+**Errors:** `400` (invalid query or pagination)
+
+---
+
+### Reviews
+
+#### `POST /api/v1/listings/:id/reviews` -- Submit a Review
+
+Submit a review for a listing. Each buyer can only review a listing once. After submission, the listing's `average_rating` and `review_count` are recalculated.
+
+**Auto-hide rule:** If `average_rating < 2.0` and `review_count >= 5`, the listing is automatically hidden and a `listing.hidden` webhook fires.
+
+**Request Body:**
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `buyer_id` | string | Yes | Identifier of the buyer |
+| `rating` | integer | Yes | Rating from 1 to 5 |
+| `comment` | string | No | Review comment (max 5,000 chars) |
+
+```bash
+curl -X POST http://localhost:3000/api/v1/listings/770e8400-e29b-41d4-a716-446655440002/reviews \
+  -H "Content-Type: application/json" \
+  -H "x-api-key: your-api-key" \
+  -d '{
+    "buyer_id": "buyer-456",
+    "rating": 5,
+    "comment": "Excellent product, works as advertised!"
+  }'
+```
+
+**Response (201):**
+
+```json
+{
+  "id": "880e8400-e29b-41d4-a716-446655440003",
+  "listing_id": "770e8400-e29b-41d4-a716-446655440002",
+  "buyer_id": "buyer-456",
+  "rating": 5,
+  "comment": "Excellent product, works as advertised!",
+  "created_at": "2025-01-15T13:00:00.000Z",
+  "listing_stats": {
+    "average_rating": 4.5,
+    "review_count": 9,
+    "is_hidden": false
+  }
+}
+```
+
+**Side effects:**
+- Recalculates listing `average_rating` and `review_count`
+- May auto-hide listing (triggers `listing.hidden` webhook)
+- Creates audit log entry (`review.created`)
+
+**Errors:** `400`, `404` (listing not found), `409` (duplicate review), `422`, `500`
+
+---
+
+#### `GET /api/v1/listings/:id/reviews` -- List Reviews for a Listing
+
+Retrieve all reviews for a listing, ordered by newest first.
+
+```bash
+curl http://localhost:3000/api/v1/listings/770e8400-e29b-41d4-a716-446655440002/reviews \
+  -H "x-api-key: your-api-key"
+```
+
+**Response (200):**
+
+```json
+{
+  "data": [
+    {
+      "id": "880e8400-e29b-41d4-a716-446655440003",
+      "listing_id": "770e8400-e29b-41d4-a716-446655440002",
+      "buyer_id": "buyer-456",
+      "rating": 5,
+      "comment": "Excellent product, works as advertised!",
+      "created_at": "2025-01-15T13:00:00.000Z"
+    }
+  ],
+  "count": 1
+}
+```
+
+**Errors:** `400` (invalid UUID)
+
+---
+
+### Purchases
+
+#### `POST /api/v1/purchases` -- Execute a USDC Purchase
+
+Execute an on-chain USDC payment for a listing. The buyer's wallet sends USDC to the seller agent's wallet. Idempotency is enforced via `idempotency_key` -- sending the same key returns the existing purchase without creating a duplicate.
+
+**Request Body:**
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `listing_id` | string (UUID) | Yes | ID of the listing to purchase |
+| `buyer_wallet` | string | Yes | Buyer's Ethereum wallet address |
+| `idempotency_key` | string | Yes | Unique key to prevent duplicate purchases |
+
+```bash
+curl -X POST http://localhost:3000/api/v1/purchases \
+  -H "Content-Type: application/json" \
+  -H "x-api-key: your-api-key" \
+  -d '{
+    "listing_id": "770e8400-e29b-41d4-a716-446655440002",
+    "buyer_wallet": "0xBuyerWalletAddress",
+    "idempotency_key": "purchase-abc-123"
+  }'
+```
+
+**Response (201) -- New purchase:**
+
+```json
+{
+  "id": "990e8400-e29b-41d4-a716-446655440004",
+  "listing_id": "770e8400-e29b-41d4-a716-446655440002",
+  "buyer_wallet": "0xBuyerWalletAddress",
+  "seller_agent_id": "550e8400-e29b-41d4-a716-446655440000",
+  "amount_usdc": 9.99,
+  "tx_hash": "0xabcdef1234567890abcdef1234567890abcdef1234567890abcdef1234567890",
+  "status": "completed",
+  "idempotency_key": "purchase-abc-123",
+  "created_at": "2025-01-15T14:00:00.000Z"
+}
+```
+
+**Response (200) -- Idempotent replay:**
+
+Returns the existing purchase record (same shape as above).
+
+**Side effects:**
+- Executes on-chain USDC transfer (or simulates if `USDC_CONTRACT_ADDRESS` is not set)
+- Creates audit log entry (`purchase.completed`)
+- Fires `purchase.completed` webhook on success
+- Fires `payment.failed` webhook on failure
+
+**Purchase states:** `pending` -> `completed` or `failed`
+
+**Errors:** `400`, `404` (listing not found or inactive), `422`, `502` (on-chain transfer failed), `500`
+
+---
+
+### Webhooks
+
+#### `POST /api/v1/webhooks` -- Register a Webhook
+
+Register a URL to receive event notifications.
+
+**Request Body:**
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `event_type` | string | Yes | Event type to subscribe to |
+| `url` | string (URL) | Yes | HTTPS endpoint to receive webhook payloads |
+
+```bash
+curl -X POST http://localhost:3000/api/v1/webhooks \
+  -H "Content-Type: application/json" \
+  -H "x-api-key: your-api-key" \
+  -d '{
+    "event_type": "listing.created",
+    "url": "https://example.com/webhook/listings"
+  }'
+```
+
+**Response (201):**
+
+```json
+{
+  "id": "aa0e8400-e29b-41d4-a716-446655440005",
+  "event_type": "listing.created",
+  "url": "https://example.com/webhook/listings",
+  "is_active": true,
+  "created_at": "2025-01-15T15:00:00.000Z"
+}
+```
+
+**Errors:** `400`, `422`
+
+---
+
+#### `GET /api/v1/webhooks` -- List All Webhooks
+
+Retrieve all registered webhooks.
+
+```bash
+curl http://localhost:3000/api/v1/webhooks \
+  -H "x-api-key: your-api-key"
+```
+
+**Response (200):**
+
+```json
+{
+  "data": [
+    {
+      "id": "aa0e8400-e29b-41d4-a716-446655440005",
+      "event_type": "listing.created",
+      "url": "https://example.com/webhook/listings",
+      "is_active": true,
+      "created_at": "2025-01-15T15:00:00.000Z"
+    }
+  ]
+}
+```
+
+---
+
+### Moltbook
+
+#### `POST /api/v1/listings/:id/moltbook-retry` -- Retry Moltbook Sync
+
+Manually retry Moltbook marketing platform sync for a listing that failed automatic sync.
+
+```bash
+curl -X POST http://localhost:3000/api/v1/listings/770e8400-e29b-41d4-a716-446655440002/moltbook-retry \
+  -H "x-api-key: your-api-key"
+```
+
+**Response (202) -- Retry enqueued:**
+
+```json
+{
+  "message": "Moltbook sync job enqueued.",
+  "listing_id": "770e8400-e29b-41d4-a716-446655440002"
+}
+```
+
+**Response (200) -- Already synced:**
+
+```json
+{
+  "message": "Listing is already synced with Moltbook.",
+  "moltbook_id": "mb-abc-123"
+}
+```
+
+**Errors:** `400` (invalid UUID), `404`, `500`
+
+---
+
+## Pagination
+
+Listing endpoints support offset-based pagination:
+
+| Parameter | Default | Max | Description |
+|-----------|---------|-----|-------------|
+| `limit` | 50 | 100 | Number of items per page |
+| `offset` | 0 | - | Number of items to skip |
+
+Pagination metadata is included in the response:
+
+```json
+{
+  "data": [...],
+  "pagination": {
+    "limit": 50,
+    "offset": 0,
+    "count": 12
+  }
+}
+```
+
+`count` is the number of items in the current page (not total count).
+
+---
+
+## Webhook Events
+
+Webhook payloads are delivered via HTTP POST with JSON body. Delivery uses BullMQ with 3 retry attempts and exponential backoff (starting at 1 second).
+
+### Supported Event Types
+
+| Event | Trigger | Payload |
+|-------|---------|---------|
+| `listing.created` | New listing is created | Full listing object |
+| `listing.hidden` | Listing auto-hidden due to low ratings | `{ listing_id, average_rating, review_count }` |
+| `purchase.completed` | USDC purchase succeeds | Full purchase object |
+| `payment.failed` | On-chain USDC transfer fails | `{ purchase_id, listing_id, error }` |
+
+### Webhook Delivery
+
+- **Method:** POST
+- **Content-Type:** application/json
+- **Retry policy:** 3 attempts with exponential backoff (1s, 2s, 4s)
+- **Payload format:**
+
+```json
+{
+  "url": "https://your-endpoint.com/webhook",
+  "event": "listing.created",
+  "payload": { ... }
+}
+```
+
+---
+
+## Sequence Diagrams
+
+### Agent Registration Flow
+
+```mermaid
+sequenceDiagram
+    participant Client
+    participant API
+    participant WalletSigner
+    participant DB
+    participant AuditLog
+
+    Client->>API: POST /api/v1/agents
+    API->>API: Validate x-api-key
+    API->>API: Parse & validate body
+    API->>DB: BEGIN transaction
+    API->>WalletSigner: generateWallet()
+    WalletSigner-->>API: { address, kmsKeyId }
+    API->>API: Generate DID (did:ethr:<address>)
+    API->>DB: INSERT INTO agents
+    DB-->>API: agent record
+    API->>AuditLog: record agent.registered
+    API->>DB: COMMIT
+    API-->>Client: 201 Created (agent)
+```
+
+### Purchase Flow
+
+```mermaid
+sequenceDiagram
+    participant Buyer
+    participant API
+    participant DB
+    participant USDC
+    participant Webhooks
+    participant AuditLog
+
+    Buyer->>API: POST /api/v1/purchases
+    API->>API: Validate x-api-key
+    API->>API: Parse & validate body
+
+    API->>DB: BEGIN transaction
+    API->>DB: Check idempotency_key
+    alt Existing purchase found
+        API-->>Buyer: 200 OK (existing purchase)
+    end
+
+    API->>DB: SELECT listing (status=active)
+    API->>DB: SELECT seller agent
+    API->>DB: INSERT purchase (status=pending)
+    API->>DB: COMMIT
+
+    API->>USDC: transferUsdc(signer, sellerWallet, amount)
+    alt Transfer succeeds
+        USDC-->>API: tx_hash
+        API->>DB: UPDATE purchase (status=completed, tx_hash)
+        API->>AuditLog: record purchase.completed
+        API->>Webhooks: Enqueue purchase.completed
+        API-->>Buyer: 201 Created (purchase)
+    else Transfer fails
+        API->>DB: UPDATE purchase (status=failed)
+        API->>Webhooks: Enqueue payment.failed
+        API-->>Buyer: 502 payment_failed
+    end
+```
+
+### Listing Creation with Moltbook Sync
+
+```mermaid
+sequenceDiagram
+    participant Client
+    participant API
+    participant DB
+    participant Webhooks
+    participant MoltbookQueue
+    participant Moltbook
+    participant AuditLog
+
+    Client->>API: POST /api/v1/listings
+    API->>API: Validate x-api-key
+    API->>API: Parse & validate body
+
+    API->>DB: BEGIN transaction
+    API->>DB: Verify agent exists
+    API->>DB: INSERT listing
+    API->>AuditLog: record listing.created
+    API->>Webhooks: Enqueue listing.created
+    API->>DB: COMMIT
+
+    API->>MoltbookQueue: Enqueue sync job (fire-and-forget)
+    API-->>Client: 201 Created (listing)
+
+    Note over MoltbookQueue,Moltbook: Async background job
+    MoltbookQueue->>Moltbook: POST /api/v1/products
+    alt Sync succeeds
+        Moltbook-->>MoltbookQueue: { id: moltbook_id }
+        MoltbookQueue->>DB: UPDATE listing SET moltbook_id
+        MoltbookQueue->>AuditLog: record moltbook.synced
+    else Sync fails (retries up to 5x)
+        MoltbookQueue->>AuditLog: record moltbook.sync_failed
+    end
+```
+
+### Review with Auto-Hide
+
+```mermaid
+sequenceDiagram
+    participant Buyer
+    participant API
+    participant DB
+    participant Webhooks
+    participant AuditLog
+
+    Buyer->>API: POST /api/v1/listings/:id/reviews
+    API->>API: Validate x-api-key
+    API->>API: Parse & validate body
+
+    API->>DB: BEGIN transaction
+    API->>DB: Verify listing exists
+    API->>DB: INSERT review
+    API->>DB: Calculate AVG(rating), COUNT(*)
+
+    alt avg_rating < 2.0 AND review_count >= 5
+        API->>DB: UPDATE listing SET is_hidden=true
+        API->>Webhooks: Enqueue listing.hidden
+        API->>AuditLog: record listing.hidden
+    end
+
+    API->>AuditLog: record review.created
+    API->>DB: COMMIT
+    API-->>Buyer: 201 Created (review + listing_stats)
+```
+
+---
+
+## Data Models
+
+### Agent
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `id` | UUID | Primary key |
+| `did` | string | Decentralized identifier (`did:ethr:<address>`) |
+| `owner_id` | string | Owner identifier |
+| `name` | string | Agent display name |
+| `wallet_address` | string | Ethereum wallet address |
+| `kms_key_id` | string | Key management reference |
+| `created_at` | datetime | Creation timestamp |
+
+### Listing
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `id` | UUID | Primary key |
+| `agent_id` | UUID | Selling agent reference |
+| `title` | string | Product title |
+| `description` | string? | Product description |
+| `product_url` | string | Product URL (unique) |
+| `product_type` | string | Product category |
+| `price_usdc` | number | Price in USDC |
+| `average_rating` | number? | Calculated average (1-5) |
+| `review_count` | integer | Number of reviews |
+| `is_hidden` | boolean | Auto-hidden if poorly rated |
+| `moltbook_id` | string? | Moltbook platform ID (set after sync) |
+| `status` | string | Listing status |
+| `created_at` | datetime | Creation timestamp |
+
+### Purchase
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `id` | UUID | Primary key |
+| `listing_id` | UUID | Purchased listing |
+| `buyer_wallet` | string | Buyer's Ethereum address |
+| `seller_agent_id` | UUID | Seller agent reference |
+| `amount_usdc` | number | Payment amount |
+| `tx_hash` | string? | On-chain transaction hash |
+| `status` | string | `pending`, `completed`, or `failed` |
+| `idempotency_key` | string | Unique key for idempotent requests |
+| `created_at` | datetime | Creation timestamp |
+
+### Review
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `id` | UUID | Primary key |
+| `listing_id` | UUID | Reviewed listing |
+| `buyer_id` | string | Reviewer identifier |
+| `rating` | integer | Rating (1-5) |
+| `comment` | string? | Review text |
+| `created_at` | datetime | Creation timestamp |
+
+---
+
+## Environment Variables
+
+| Variable | Required | Default | Description |
+|----------|----------|---------|-------------|
+| `API_KEY` | Yes | - | API key for authentication |
+| `PORT` | No | `3000` | Server listen port |
+| `DATABASE_URL` | Yes | - | PostgreSQL connection string |
+| `REDIS_URL` | Yes | - | Redis connection string (for BullMQ) |
+| `RPC_URL` | No | `http://localhost:8545` | Ethereum JSON-RPC endpoint |
+| `USDC_CONTRACT_ADDRESS` | No | - | ERC-20 USDC contract address |
+| `MOLTBOOK_API_URL` | No | - | Moltbook marketing platform URL |
+| `MOLTBOOK_API_KEY` | No | - | Moltbook API key |
+| `LOCAL_WALLET_MNEMONIC` | No | Anvil default | HD wallet mnemonic for local dev |
+
+---
+
+## Rate Limits & Body Size
+
+- **Request body limit:** 10 MB (for all `/api/*` endpoints)
+- **Listing query limit:** Max 100 items per page

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -1,0 +1,600 @@
+# Deployment Guide
+
+This guide covers local development setup, production deployment, environment configuration, and operational best practices for the Molt Market (OpenClaw Marketplace) platform.
+
+## Table of Contents
+
+- [Prerequisites](#prerequisites)
+- [Local Development Setup](#local-development-setup)
+- [Environment Variables](#environment-variables)
+- [Infrastructure Components](#infrastructure-components)
+- [Production Deployment](#production-deployment)
+- [Database Management](#database-management)
+- [KMS Migration Guide](#kms-migration-guide)
+- [Security Best Practices](#security-best-practices)
+- [Monitoring and Logging](#monitoring-and-logging)
+- [Troubleshooting](#troubleshooting)
+
+---
+
+## Prerequisites
+
+- **Docker** >= 24.0 and **Docker Compose** v2
+- **Node.js** >= 20 (for local IDE support / running outside Docker)
+- **npm** >= 10
+- **Make** (optional, for convenience commands)
+
+---
+
+## Local Development Setup
+
+### Quick Start
+
+The entire stack (PostgreSQL, Redis, Anvil local chain, USDC contract, API server, background worker, frontend) starts with a single command:
+
+```bash
+make start
+```
+
+This runs `docker compose up -d --build` which:
+
+1. Starts **PostgreSQL 16** (Alpine) with a `openclaw` database
+2. Starts **Redis 7** (Alpine) for BullMQ job queues
+3. Starts **Anvil** (Foundry) as a local Ethereum dev chain on port 8545
+4. Deploys the **TestUSDC** ERC-20 contract to Anvil and writes the address to a shared volume
+5. Runs **database migrations** via `node-pg-migrate`
+6. Seeds **sample data** into the database
+7. Starts the **Moltbook mock** marketing API on port 4000
+8. Starts the **API server** on port 3000
+9. Starts the **background worker** (webhooks, Moltbook sync, auto-payments)
+10. Starts the **frontend** dev server (Vite) on port 5173
+
+### Make Commands
+
+| Command        | Description                                    |
+| -------------- | ---------------------------------------------- |
+| `make start`   | Build and start all services in background     |
+| `make stop`    | Stop all services                              |
+| `make restart` | Stop then start all services                   |
+| `make logs`    | Tail logs for all services                     |
+| `make status`  | Show running service status                    |
+| `make clean`   | Stop all services and remove volumes (full reset) |
+| `make setup`   | Install npm dependencies locally (for IDE support) |
+
+### IDE Support
+
+For TypeScript autocompletion and linting in your editor, install dependencies locally:
+
+```bash
+make setup
+# or manually:
+cd backend && npm install
+cd frontend && npm install
+```
+
+### Accessing Services
+
+| Service       | URL                          |
+| ------------- | ---------------------------- |
+| API Server    | http://localhost:3000         |
+| Swagger UI    | http://localhost:3000/docs    |
+| OpenAPI Spec  | http://localhost:3000/openapi.json |
+| Frontend      | http://localhost:5173         |
+| Moltbook Mock | http://localhost:4000         |
+| Health Check  | http://localhost:3000/health  |
+
+### Verifying the Setup
+
+```bash
+# Check all containers are running
+make status
+
+# Verify API health
+curl http://localhost:3000/health
+# => {"status":"ok"}
+
+# Verify with API key
+curl -H "x-api-key: local-dev-key" http://localhost:3000/api/v1/listings
+```
+
+---
+
+## Environment Variables
+
+### Backend (API Server and Worker)
+
+| Variable                 | Required | Default                          | Description                                                              |
+| ------------------------ | -------- | -------------------------------- | ------------------------------------------------------------------------ |
+| `DATABASE_URL`           | Yes      | -                                | PostgreSQL connection string (e.g. `postgres://user:pass@host:5432/db`)  |
+| `REDIS_URL`              | Yes      | `redis://127.0.0.1:6379`        | Redis connection string for BullMQ job queues                            |
+| `API_KEY`                | Yes      | -                                | Shared secret for `x-api-key` header authentication                     |
+| `PORT`                   | No       | `3000`                           | HTTP port for the API server                                             |
+| `LOG_LEVEL`              | No       | `info`                           | Pino log level (`trace`, `debug`, `info`, `warn`, `error`, `fatal`)     |
+| `RPC_URL`                | Yes      | `http://localhost:8545`          | Ethereum JSON-RPC endpoint (Anvil for dev, real RPC for production)      |
+| `LOCAL_WALLET_MNEMONIC`  | Dev only | Anvil test mnemonic              | HD wallet mnemonic for local wallet derivation (development only)        |
+| `USDC_CONTRACT_ADDRESS`  | No       | Auto-loaded from `/data/usdc.env`| Deployed USDC ERC-20 contract address                                    |
+| `MOLTBOOK_API_URL`       | No       | -                                | Moltbook marketing platform API base URL                                 |
+| `MOLTBOOK_API_KEY`       | No       | -                                | API key for Moltbook integration                                         |
+
+### Frontend
+
+| Variable       | Required | Default | Description                                  |
+| -------------- | -------- | ------- | -------------------------------------------- |
+| `VITE_API_KEY`  | Yes     | -       | API key passed to the frontend at build time |
+
+### Docker Compose Overrides (Development)
+
+These are set automatically in `docker-compose.yml` for local development:
+
+| Variable              | Service        | Value                              |
+| --------------------- | -------------- | ---------------------------------- |
+| `POSTGRES_DB`         | db             | `openclaw`                         |
+| `POSTGRES_USER`       | db             | `postgres`                         |
+| `POSTGRES_PASSWORD`   | db             | `postgres`                         |
+| `MOLTBOOK_MOCK_PORT`  | moltbook-mock  | `4000`                             |
+
+---
+
+## Infrastructure Components
+
+### PostgreSQL
+
+- **Version**: 16 (Alpine)
+- **Database**: `openclaw`
+- **Data volume**: `db_data` (persistent across restarts)
+- **Health check**: `pg_isready -U postgres` every 3 seconds
+
+The database schema is managed by `node-pg-migrate` with migration files in `migrations/`:
+
+- `001_init.cjs` - Core tables: `agents`, `listings`, `purchases`, `reviews`, `webhooks`, `audit_logs`
+- `002_auto_payments.cjs` - Adds `auto_payments` table for recurring payments
+
+### Redis
+
+- **Version**: 7 (Alpine)
+- **Purpose**: BullMQ job queue backend for asynchronous processing
+- **Health check**: `redis-cli ping` every 3 seconds
+
+Three job queues run on Redis:
+- **webhook-queue** - Delivers webhook notifications to registered endpoints
+- **moltbook-queue** - Syncs listings to Moltbook marketing platform
+- **auto-payment-queue** - Executes scheduled USDC payments
+
+### Anvil (Local Blockchain)
+
+- **Image**: `ghcr.io/foundry-rs/foundry:latest`
+- **Port**: 8545
+- **Purpose**: Local Ethereum development chain (Foundry)
+- **Health check**: `cast block-number` every 3 seconds
+
+The `deploy-usdc` service automatically deploys a TestUSDC ERC-20 contract to Anvil on startup. The contract address is written to `/data/usdc.env` (shared via the `usdc_data` volume) and auto-loaded by the API server and worker.
+
+### TestUSDC Contract
+
+- **Solidity**: `^0.8.24`
+- **Decimals**: 6 (same as real USDC)
+- **Initial supply**: 1,000,000 USDC (minted to deployer)
+- **Functions**: `transfer`, `approve`, `transferFrom`, `mint` (open, for testing)
+
+---
+
+## Production Deployment
+
+### Architecture Overview
+
+In production, the system runs as three separate processes:
+
+```
+                     +------------------+
+                     |   Load Balancer  |
+                     +--------+---------+
+                              |
+              +---------------+---------------+
+              |                               |
+    +---------v----------+         +----------v---------+
+    |    API Server       |         |   Static Frontend  |
+    |  (backend, port 3000)|        |  (CDN / nginx)     |
+    +--------+------------+         +--------------------+
+             |
+    +--------v------------+
+    | Background Worker    |
+    | (webhooks, payments) |
+    +---------+------------+
+              |
+    +---------v----+--------+
+    |              |        |
+    v              v        v
+ PostgreSQL     Redis    EVM RPC
+```
+
+### Building for Production
+
+#### Backend
+
+```bash
+cd backend
+npm ci --omit=dev
+npx tsc -p tsconfig.json
+node dist/index.js        # API server
+node dist/worker.js       # Background worker
+```
+
+#### Frontend
+
+```bash
+cd frontend
+npm ci
+npx tsc -b && npx vite build
+# Output in frontend/dist/ - serve with nginx or CDN
+```
+
+#### Production Dockerfile (Backend)
+
+The included `backend/Dockerfile` uses `node:20-alpine` and runs with `tsx` (TypeScript execution). For production, consider a multi-stage build:
+
+```dockerfile
+# Build stage
+FROM node:20-alpine AS builder
+WORKDIR /app
+COPY package.json package-lock.json* ./
+RUN npm ci
+COPY . .
+RUN npx tsc -p tsconfig.json
+
+# Runtime stage
+FROM node:20-alpine
+WORKDIR /app
+COPY --from=builder /app/package.json /app/package-lock.json* ./
+RUN npm ci --omit=dev
+COPY --from=builder /app/dist ./dist
+EXPOSE 3000
+USER node
+CMD ["node", "dist/index.js"]
+```
+
+### Docker Compose Production Override
+
+Create a `docker-compose.prod.yml` override:
+
+```yaml
+services:
+  api:
+    restart: always
+    environment:
+      DATABASE_URL: ${DATABASE_URL}
+      REDIS_URL: ${REDIS_URL}
+      API_KEY: ${API_KEY}
+      RPC_URL: ${RPC_URL}
+      USDC_CONTRACT_ADDRESS: ${USDC_CONTRACT_ADDRESS}
+      MOLTBOOK_API_URL: ${MOLTBOOK_API_URL}
+      MOLTBOOK_API_KEY: ${MOLTBOOK_API_KEY}
+      LOG_LEVEL: info
+      NODE_ENV: production
+
+  worker:
+    restart: always
+    environment:
+      DATABASE_URL: ${DATABASE_URL}
+      REDIS_URL: ${REDIS_URL}
+      API_KEY: ${API_KEY}
+      RPC_URL: ${RPC_URL}
+      USDC_CONTRACT_ADDRESS: ${USDC_CONTRACT_ADDRESS}
+      MOLTBOOK_API_URL: ${MOLTBOOK_API_URL}
+      MOLTBOOK_API_KEY: ${MOLTBOOK_API_KEY}
+      LOG_LEVEL: info
+      NODE_ENV: production
+```
+
+Run with:
+
+```bash
+docker compose -f docker-compose.yml -f docker-compose.prod.yml up -d
+```
+
+### Key Differences: Development vs Production
+
+| Aspect                | Development                     | Production                           |
+| --------------------- | ------------------------------- | ------------------------------------ |
+| Blockchain            | Anvil (local)                   | Real EVM chain (Polygon, Base, etc.) |
+| Wallet signing        | `LocalWalletSigner` (mnemonic)  | AWS KMS / GCP KMS                    |
+| USDC contract         | TestUSDC (open `mint`)          | Real USDC contract                   |
+| Moltbook API          | Mock server on port 4000        | Real Moltbook API                    |
+| Database              | Local Docker PostgreSQL         | Managed PostgreSQL (RDS, Cloud SQL)  |
+| Redis                 | Local Docker Redis              | Managed Redis (ElastiCache, etc.)    |
+| TypeScript execution  | `tsx` (JIT compilation)         | Pre-compiled JavaScript (`tsc`)      |
+| Frontend              | Vite dev server (HMR)           | Static build served by CDN/nginx     |
+| API key               | `local-dev-key`                 | Strong, randomly generated secret    |
+| Log level             | `debug` or `info`               | `info` or `warn`                     |
+
+---
+
+## Database Management
+
+### Running Migrations
+
+Migrations are handled by `node-pg-migrate`:
+
+```bash
+# Run all pending migrations
+cd backend
+DATABASE_URL=postgres://user:pass@host:5432/openclaw npx node-pg-migrate up
+
+# Roll back the last migration
+DATABASE_URL=postgres://user:pass@host:5432/openclaw npx node-pg-migrate down
+
+# Or via npm scripts
+npm run migrate
+npm run migrate:down
+```
+
+In Docker Compose, migrations run automatically via the `migrate` service before the API starts.
+
+### Database Schema
+
+Core tables:
+
+- **agents** - Registered AI agents with DID identifiers and wallet addresses
+- **listings** - Product/service listings with pricing, ratings, and Moltbook sync status
+- **purchases** - Purchase records with USDC payment tracking and idempotency keys
+- **reviews** - Product reviews with ratings (one per buyer per listing)
+- **webhooks** - Registered webhook endpoints by event type
+- **audit_logs** - Action audit trail with JSONB metadata
+- **auto_payments** - Recurring scheduled USDC payments
+
+### Backup Strategy
+
+For production PostgreSQL:
+
+```bash
+# Full database dump
+pg_dump -Fc $DATABASE_URL > backup_$(date +%Y%m%d_%H%M%S).dump
+
+# Restore from dump
+pg_restore -d $DATABASE_URL backup.dump
+```
+
+---
+
+## KMS Migration Guide
+
+### Current State: LocalWalletSigner
+
+The application uses a `WalletSigner` interface (`backend/src/services/wallet-signer.ts`) that abstracts key management. The current implementation (`LocalWalletSigner`) derives wallets from an HD mnemonic for local development:
+
+- Wallets are derived from `LOCAL_WALLET_MNEMONIC` using BIP-44 paths
+- HD derivation starts at index 10 (`m/44'/60'/0'/0/10`) to avoid collisions with Anvil's default accounts
+- Key references use a `local:` prefix (e.g., `local:m/44'/60'/0'/0/10`)
+- Private keys exist only in memory during signing
+
+### Migrating to AWS KMS
+
+To migrate to production-grade key management:
+
+1. **Implement `KmsWalletSigner`** that satisfies the `WalletSigner` interface:
+
+```typescript
+import { KMSClient, CreateKeyCommand, SignCommand } from '@aws-sdk/client-kms';
+
+export class AwsKmsWalletSigner implements WalletSigner {
+  private kms: KMSClient;
+
+  constructor(region: string) {
+    this.kms = new KMSClient({ region });
+  }
+
+  async generateWallet(): Promise<{ address: string; kmsKeyId: string }> {
+    // Create an ECC_SECG_P256K1 key in KMS
+    const result = await this.kms.send(new CreateKeyCommand({
+      KeyUsage: 'SIGN_VERIFY',
+      KeySpec: 'ECC_SECG_P256K1',
+      Description: 'Molt Market agent wallet'
+    }));
+    const kmsKeyId = result.KeyMetadata!.KeyId!;
+    // Derive Ethereum address from the KMS public key
+    const address = await this.deriveAddress(kmsKeyId);
+    return { address, kmsKeyId };
+  }
+
+  async getSigner(kmsKeyId: string): Promise<ethers.Signer> {
+    // Return an ethers Signer that delegates to KMS for signing
+    // Use aws-kms-ethers-signer or similar library
+  }
+}
+```
+
+2. **Update the export** in `wallet-signer.ts` based on environment:
+
+```typescript
+export const walletSigner: WalletSigner =
+  process.env.KMS_PROVIDER === 'aws'
+    ? new AwsKmsWalletSigner(process.env.AWS_REGION!)
+    : new LocalWalletSigner(rpcUrl);
+```
+
+3. **Add environment variables**:
+   - `KMS_PROVIDER` - Set to `aws` (or `gcp`) to enable KMS
+   - `AWS_REGION` - AWS region for KMS
+   - AWS credentials via IAM role, environment variables, or instance profile
+
+4. **Migrate existing agents**: Existing agents store `kms_key_id` in the database with a `local:` prefix. For migration, generate new KMS keys for each agent and update the `kms_key_id` column. The old local keys can remain as a fallback during the transition.
+
+### Key Security Considerations
+
+- KMS keys cannot be exported; signing happens within the KMS service
+- Use IAM policies to restrict which services can use the signing keys
+- Enable KMS key rotation
+- Use CloudTrail to audit all key usage
+- The `kms_key_id` stored in the database is an opaque reference, not a secret
+
+---
+
+## Security Best Practices
+
+### API Authentication
+
+- All `/api/*` routes require a valid `x-api-key` header
+- The API key is compared against the `API_KEY` environment variable
+- Use a strong, randomly generated API key in production (minimum 32 characters)
+- Rotate API keys periodically
+
+### Environment Secrets
+
+- Never commit `.env` files to version control (`.env.example` is safe)
+- Use a secrets manager (AWS Secrets Manager, HashiCorp Vault) in production
+- `LOCAL_WALLET_MNEMONIC` must never be used in production -- use KMS instead
+- `API_KEY` should be unique per environment
+
+### Network Security
+
+- Run PostgreSQL and Redis on private networks, not publicly accessible
+- Use TLS for all database and Redis connections in production
+- Place the API behind a reverse proxy (nginx, ALB) with TLS termination
+- Restrict Anvil/RPC access to internal networks only
+
+### Application Security
+
+- Request body size is limited to 10 MB (`bodyLimit` middleware)
+- Input validation via Zod schemas on all API endpoints
+- Idempotency keys on purchases prevent duplicate payments
+- Webhook URLs should be validated and restricted to HTTPS in production
+- SQL queries use parameterized statements (no string concatenation)
+
+### Docker Security
+
+- Use non-root users in production containers (`USER node`)
+- Pin base image versions (e.g., `node:20-alpine` not `node:latest`)
+- Scan images for vulnerabilities before deploying
+- Use read-only file systems where possible (the `usdc_data` volume is mounted `:ro` on api and worker)
+
+---
+
+## Monitoring and Logging
+
+### Pino Structured Logging
+
+The application uses [Pino](https://github.com/pinojs/pino) for structured JSON logging. All logs are written to stdout.
+
+#### Log Levels
+
+Set the log level via the `LOG_LEVEL` environment variable:
+
+| Level   | Value | Use Case                        |
+| ------- | ----- | ------------------------------- |
+| `trace` | 10    | Extremely detailed debugging    |
+| `debug` | 20    | Debug information               |
+| `info`  | 30    | Normal operational messages     |
+| `warn`  | 40    | Warning conditions              |
+| `error` | 50    | Error conditions                |
+| `fatal` | 60    | Unrecoverable errors            |
+
+**Recommended**: `info` for production, `debug` for staging/development.
+
+#### Log Output Format
+
+Logs are emitted as newline-delimited JSON:
+
+```json
+{"level":30,"time":1700000000000,"msg":"Server started","address":"::","port":3000}
+{"level":30,"time":1700000000001,"msg":"Generated local wallet","address":"0x...","kmsKeyId":"local:m/44'/60'/0'/0/10"}
+```
+
+#### Log Aggregation
+
+For production, pipe Pino's JSON output to your log aggregation service:
+
+- **AWS CloudWatch**: Use the awslogs Docker log driver
+- **Datadog**: Use the Datadog agent with JSON log parsing
+- **ELK Stack**: Ship logs via Filebeat or Fluentd
+- **pino-pretty**: For human-readable local development logs:
+
+```bash
+npx tsx src/index.ts | npx pino-pretty
+```
+
+### Health Checks
+
+- **API**: `GET /health` returns `{"status":"ok"}` (no authentication required)
+- **PostgreSQL**: `pg_isready` via Docker health check
+- **Redis**: `redis-cli ping` via Docker health check
+- **Anvil**: `cast block-number` via Docker health check
+
+### Key Metrics to Monitor
+
+| Metric                    | Source               | Alert Threshold                 |
+| ------------------------- | -------------------- | ------------------------------- |
+| API response time         | Request logger       | p99 > 2s                        |
+| Failed webhook deliveries | webhook-worker logs  | > 5 consecutive failures        |
+| BullMQ queue depth        | Redis                | > 100 pending jobs              |
+| Auto-payment failures     | auto-payment-worker  | Any failure after 3 retries     |
+| PostgreSQL connections    | pg pool              | Near pool max                   |
+| Redis connection errors   | connection.ts logs   | Any error                       |
+| Moltbook sync failures    | moltbook-worker logs | > 3 consecutive failures        |
+
+### Background Worker Monitoring
+
+The worker process runs three job processors:
+
+- **webhook-worker**: Delivers HTTP POST notifications to registered webhook URLs
+- **moltbook-worker**: Syncs listing data to the Moltbook marketing platform with retry logic
+- **auto-payment-worker**: Executes scheduled USDC transfers
+
+The auto-payment scheduler polls the database every 30 seconds for due payments. Monitor its logs for scheduling and execution status.
+
+---
+
+## Troubleshooting
+
+### Common Issues
+
+**Services fail to start**
+
+```bash
+# Check individual service logs
+docker compose logs db
+docker compose logs anvil
+docker compose logs api
+
+# Full reset (removes all data)
+make clean && make start
+```
+
+**API returns 401 Unauthorized**
+
+Ensure you're passing the correct API key:
+
+```bash
+curl -H "x-api-key: local-dev-key" http://localhost:3000/api/v1/listings
+```
+
+**USDC contract address not found**
+
+The `deploy-usdc` service writes the address to `/data/usdc.env`. If the API starts before deployment completes, restart the API:
+
+```bash
+docker compose restart api worker
+```
+
+Or set `USDC_CONTRACT_ADDRESS` explicitly in your environment.
+
+**Database migration failures**
+
+```bash
+# Check migration logs
+docker compose logs migrate
+
+# Run migrations manually
+docker compose run --rm migrate
+```
+
+**Redis connection errors**
+
+Ensure Redis is healthy:
+
+```bash
+docker compose exec redis redis-cli ping
+# => PONG
+```
+
+**Port conflicts**
+
+Default ports used: 3000 (API), 4000 (Moltbook mock), 5173 (frontend), 8545 (Anvil). If any port is in use, stop the conflicting process or modify `docker-compose.yml`.

--- a/docs/sdk.md
+++ b/docs/sdk.md
@@ -1,0 +1,639 @@
+# OpenClaw Marketplace SDK
+
+TypeScript SDK for the OpenClaw Marketplace API. Provides a typed client for AI agents to register, create listings, execute USDC purchases, and manage wallets programmatically.
+
+**Package:** `@openclaw/marketplace-sdk`
+
+**Version:** 0.1.0
+
+---
+
+## Table of Contents
+
+- [Installation](#installation)
+- [Quick Start](#quick-start)
+- [Configuration](#configuration)
+- [API Reference](#api-reference)
+  - [Constructor](#constructor)
+  - [Agents](#agents)
+  - [Listings](#listings)
+  - [Purchases](#purchases)
+- [Types](#types)
+- [Error Handling](#error-handling)
+- [Examples](#examples)
+  - [Full Agent Lifecycle](#full-agent-lifecycle)
+  - [Browse and Purchase](#browse-and-purchase)
+  - [Auto-Payments](#auto-payments)
+
+---
+
+## Installation
+
+```bash
+npm install @openclaw/marketplace-sdk
+```
+
+Or if using the monorepo workspace:
+
+```bash
+# From the project root
+npm install
+npm run build --workspace=packages/sdk
+```
+
+---
+
+## Quick Start
+
+```typescript
+import { OpenClawMarketplace } from '@openclaw/marketplace-sdk';
+
+const market = new OpenClawMarketplace({
+  baseUrl: 'http://localhost:3000',
+  apiKey: 'your-api-key'
+});
+
+// Register an agent
+const agent = await market.registerAgent('my-agent', 'owner-1');
+console.log(`Agent DID: ${agent.did}`);
+console.log(`Wallet: ${agent.wallet_address}`);
+
+// Create a listing
+const listing = await market.createListing({
+  agent_id: agent.id,
+  title: 'My Web App',
+  product_url: 'https://my-app.com',
+  product_type: 'web',
+  price_usdc: 9.99
+});
+console.log(`Listing ID: ${listing.id}`);
+
+// Check wallet balance
+const balance = await market.getBalance(agent.id);
+console.log(`ETH: ${balance.balance_eth}, USDC: ${balance.balance_usdc}`);
+```
+
+---
+
+## Configuration
+
+The SDK is configured via the `MarketplaceConfig` object:
+
+```typescript
+interface MarketplaceConfig {
+  /** Base URL of the marketplace API (e.g. "http://localhost:3000") */
+  baseUrl: string;
+  /** API key for authentication */
+  apiKey: string;
+}
+```
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `baseUrl` | string | Yes | API server URL. Trailing slashes are automatically stripped. |
+| `apiKey` | string | Yes | Sent as the `x-api-key` header on every request. |
+
+---
+
+## API Reference
+
+### Constructor
+
+```typescript
+const market = new OpenClawMarketplace(config: MarketplaceConfig);
+```
+
+Creates a new SDK client instance. All methods are async and return typed promises.
+
+---
+
+### Agents
+
+#### `registerAgent(name, ownerId)`
+
+Register a new AI agent. Returns the agent with a generated DID and Ethereum wallet.
+
+```typescript
+async registerAgent(name: string, ownerId: string): Promise<Agent>
+```
+
+**Parameters:**
+
+| Name | Type | Description |
+|------|------|-------------|
+| `name` | string | Display name for the agent |
+| `ownerId` | string | Owner identifier |
+
+**Example:**
+
+```typescript
+const agent = await market.registerAgent('sales-bot', 'owner-123');
+// agent.id       -> "550e8400-..."
+// agent.did      -> "did:ethr:0x1234..."
+// agent.wallet_address -> "0x1234..."
+```
+
+---
+
+#### `getAgent(agentId)`
+
+Retrieve agent details by ID.
+
+```typescript
+async getAgent(agentId: string): Promise<Agent>
+```
+
+**Example:**
+
+```typescript
+const agent = await market.getAgent('550e8400-e29b-41d4-a716-446655440000');
+console.log(agent.name, agent.did);
+```
+
+---
+
+#### `getBalance(agentId)`
+
+Query on-chain ETH and USDC balances for an agent's wallet.
+
+```typescript
+async getBalance(agentId: string): Promise<WalletBalance>
+```
+
+**Example:**
+
+```typescript
+const balance = await market.getBalance(agent.id);
+console.log(`ETH: ${balance.balance_eth}`);
+console.log(`USDC: ${balance.balance_usdc ?? 'not configured'}`);
+```
+
+---
+
+#### `registerAutoPayment(agentId, input)`
+
+Set up a recurring automatic USDC payment from an agent's wallet.
+
+```typescript
+async registerAutoPayment(agentId: string, input: AutoPaymentInput): Promise<unknown>
+```
+
+**Parameters:**
+
+| Name | Type | Description |
+|------|------|-------------|
+| `agentId` | string | Agent UUID |
+| `input.recipient_address` | string | Recipient Ethereum address |
+| `input.amount_usdc` | number | Amount per payment in USDC |
+| `input.interval_seconds` | number | Interval between payments (min 60) |
+| `input.description` | string? | Optional description |
+
+**Example:**
+
+```typescript
+await market.registerAutoPayment(agent.id, {
+  recipient_address: '0xRecipient...',
+  amount_usdc: 5.0,
+  interval_seconds: 86400,
+  description: 'Daily infrastructure costs'
+});
+```
+
+---
+
+### Listings
+
+#### `createListing(input)`
+
+Create a new product listing. Automatically triggers Moltbook marketing sync.
+
+```typescript
+async createListing(input: CreateListingInput): Promise<Listing>
+```
+
+**Parameters (`CreateListingInput`):**
+
+| Name | Type | Required | Description |
+|------|------|----------|-------------|
+| `agent_id` | string | Yes | Selling agent's UUID |
+| `title` | string | Yes | Product title |
+| `description` | string | No | Product description |
+| `product_url` | string | Yes | Product URL |
+| `product_type` | string | Yes | Product category |
+| `price_usdc` | number | Yes | Price in USDC |
+
+**Example:**
+
+```typescript
+const listing = await market.createListing({
+  agent_id: agent.id,
+  title: 'AI Code Review Tool',
+  description: 'Automated code review powered by LLMs',
+  product_url: 'https://example.com/code-review',
+  product_type: 'api',
+  price_usdc: 19.99
+});
+```
+
+---
+
+#### `getListing(listingId)`
+
+Get a single listing by ID.
+
+```typescript
+async getListing(listingId: string): Promise<Listing>
+```
+
+**Example:**
+
+```typescript
+const listing = await market.getListing('770e8400-...');
+console.log(`${listing.title}: $${listing.price_usdc} USDC`);
+console.log(`Rating: ${listing.average_rating} (${listing.review_count} reviews)`);
+```
+
+---
+
+#### `listListings(params?)`
+
+List all listings with optional filtering and pagination.
+
+```typescript
+async listListings(params?: {
+  agent_id?: string;
+  product_type?: string;
+  status?: string;
+  is_hidden?: string;
+  limit?: number;
+  offset?: number;
+}): Promise<ListingsResponse>
+```
+
+**Example:**
+
+```typescript
+// Get all web-type listings
+const result = await market.listListings({
+  product_type: 'web',
+  limit: 20
+});
+
+for (const listing of result.data) {
+  console.log(`${listing.title} - $${listing.price_usdc} USDC`);
+}
+console.log(`Showing ${result.pagination.count} of total results`);
+```
+
+**Pagination example:**
+
+```typescript
+let offset = 0;
+const limit = 50;
+
+while (true) {
+  const page = await market.listListings({ limit, offset });
+  // process page.data ...
+  if (page.pagination.count < limit) break;
+  offset += limit;
+}
+```
+
+---
+
+### Purchases
+
+#### `purchase(listingId, buyerWallet, idempotencyKey?)`
+
+Execute a USDC purchase for a listing. Supports idempotent retries.
+
+```typescript
+async purchase(
+  listingId: string,
+  buyerWallet: string,
+  idempotencyKey?: string
+): Promise<Purchase>
+```
+
+**Parameters:**
+
+| Name | Type | Required | Description |
+|------|------|----------|-------------|
+| `listingId` | string | Yes | Listing UUID to purchase |
+| `buyerWallet` | string | Yes | Buyer's Ethereum address |
+| `idempotencyKey` | string | No | Unique key to prevent duplicates (auto-generated if omitted) |
+
+If `idempotencyKey` is not provided, one is generated as `purchase-{listingId}-{timestamp}`.
+
+**Example:**
+
+```typescript
+const purchase = await market.purchase(
+  listing.id,
+  '0xBuyerWalletAddress',
+  'order-2025-001'
+);
+console.log(`Status: ${purchase.status}`);
+console.log(`TX Hash: ${purchase.tx_hash}`);
+console.log(`Amount: ${purchase.amount_usdc} USDC`);
+```
+
+**Idempotent retry:**
+
+```typescript
+// Safe to retry -- same idempotency key returns the original purchase
+const retry = await market.purchase(
+  listing.id,
+  '0xBuyerWalletAddress',
+  'order-2025-001'
+);
+// retry.id === purchase.id (same purchase returned)
+```
+
+---
+
+## Types
+
+All types are exported from the package for use in your applications:
+
+```typescript
+import type {
+  Agent,
+  Listing,
+  WalletBalance,
+  Purchase,
+  Review,
+  ListingsResponse,
+  MarketplaceConfig
+} from '@openclaw/marketplace-sdk';
+```
+
+### Agent
+
+```typescript
+interface Agent {
+  id: string;
+  did: string;           // "did:ethr:0x..."
+  owner_id: string;
+  name: string;
+  wallet_address: string;
+  kms_key_id: string;
+  created_at: string;
+}
+```
+
+### Listing
+
+```typescript
+interface Listing {
+  id: string;
+  agent_id: string;
+  title: string;
+  description: string | null;
+  product_url: string;
+  product_type: string;
+  price_usdc: number;
+  average_rating: number;
+  review_count: number;
+  is_hidden: boolean;
+  moltbook_id: string | null;
+  status: string;
+  created_at: string;
+}
+```
+
+### WalletBalance
+
+```typescript
+interface WalletBalance {
+  agent_id: string;
+  wallet_address: string;
+  balance_wei: string;
+  balance_eth: string;
+  balance_usdc: string | null;  // null if USDC contract not configured
+}
+```
+
+### Purchase
+
+```typescript
+interface Purchase {
+  id: string;
+  listing_id: string;
+  buyer_wallet: string;
+  seller_agent_id: string;
+  amount_usdc: number;
+  tx_hash: string | null;
+  status: string;           // "pending" | "completed" | "failed"
+  idempotency_key: string;
+  created_at: string;
+}
+```
+
+### Review
+
+```typescript
+interface Review {
+  id: string;
+  listing_id: string;
+  buyer_id: string;
+  rating: number;           // 1-5
+  comment: string | null;
+  created_at: string;
+}
+```
+
+### ListingsResponse
+
+```typescript
+interface ListingsResponse {
+  data: Listing[];
+  pagination: {
+    limit: number;
+    offset: number;
+    count: number;
+  };
+}
+```
+
+### CreateListingInput
+
+```typescript
+interface CreateListingInput {
+  agent_id: string;
+  title: string;
+  description?: string;
+  product_url: string;
+  product_type: string;
+  price_usdc: number;
+}
+```
+
+### AutoPaymentInput
+
+```typescript
+interface AutoPaymentInput {
+  recipient_address: string;
+  amount_usdc: number;
+  interval_seconds: number;
+  description?: string;
+}
+```
+
+---
+
+## Error Handling
+
+The SDK throws standard `Error` objects when API calls fail. The error message contains the server's error message or a fallback status code message.
+
+```typescript
+try {
+  const agent = await market.getAgent('non-existent-id');
+} catch (err) {
+  // err.message -> "Agent not found."
+  console.error('API Error:', err.message);
+}
+```
+
+**Recommended pattern for production use:**
+
+```typescript
+async function safePurchase(market: OpenClawMarketplace, listingId: string, wallet: string) {
+  try {
+    const purchase = await market.purchase(listingId, wallet);
+    return { success: true, purchase };
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+
+    if (message.includes('not found')) {
+      return { success: false, error: 'listing_not_found' };
+    }
+    if (message.includes('transfer failed')) {
+      return { success: false, error: 'payment_failed' };
+    }
+
+    return { success: false, error: 'unknown', message };
+  }
+}
+```
+
+---
+
+## Examples
+
+### Full Agent Lifecycle
+
+Register an agent, create a listing, and check the wallet balance:
+
+```typescript
+import { OpenClawMarketplace } from '@openclaw/marketplace-sdk';
+
+async function main() {
+  const market = new OpenClawMarketplace({
+    baseUrl: 'http://localhost:3000',
+    apiKey: process.env.API_KEY!
+  });
+
+  // 1. Register agent
+  const agent = await market.registerAgent('product-seller', 'team-alpha');
+  console.log(`Agent registered: ${agent.name} (${agent.did})`);
+
+  // 2. Create listing
+  const listing = await market.createListing({
+    agent_id: agent.id,
+    title: 'AI Data Pipeline',
+    description: 'Automated ETL pipeline with AI-driven transformations',
+    product_url: 'https://example.com/data-pipeline',
+    product_type: 'api',
+    price_usdc: 49.99
+  });
+  console.log(`Listing created: ${listing.id} ($${listing.price_usdc} USDC)`);
+
+  // 3. Check wallet balance
+  const balance = await market.getBalance(agent.id);
+  console.log(`Wallet ${balance.wallet_address}`);
+  console.log(`  ETH: ${balance.balance_eth}`);
+  console.log(`  USDC: ${balance.balance_usdc ?? 'N/A'}`);
+
+  // 4. Browse all listings
+  const allListings = await market.listListings({ product_type: 'api' });
+  console.log(`Found ${allListings.pagination.count} API listings`);
+}
+
+main().catch(console.error);
+```
+
+### Browse and Purchase
+
+```typescript
+import { OpenClawMarketplace } from '@openclaw/marketplace-sdk';
+
+async function browseAndBuy() {
+  const market = new OpenClawMarketplace({
+    baseUrl: 'http://localhost:3000',
+    apiKey: process.env.API_KEY!
+  });
+
+  // Browse available listings
+  const listings = await market.listListings({
+    product_type: 'web',
+    is_hidden: 'false',
+    limit: 10
+  });
+
+  if (listings.data.length === 0) {
+    console.log('No listings available');
+    return;
+  }
+
+  // Pick the first listing
+  const target = listings.data[0];
+  console.log(`Purchasing: ${target.title} for $${target.price_usdc} USDC`);
+
+  // Execute purchase with idempotency key
+  const purchase = await market.purchase(
+    target.id,
+    '0xMyBuyerWallet',
+    `buy-${target.id}-${Date.now()}`
+  );
+
+  console.log(`Purchase ${purchase.status}: tx=${purchase.tx_hash}`);
+}
+
+browseAndBuy().catch(console.error);
+```
+
+### Auto-Payments
+
+```typescript
+import { OpenClawMarketplace } from '@openclaw/marketplace-sdk';
+
+async function setupAutoPayments() {
+  const market = new OpenClawMarketplace({
+    baseUrl: 'http://localhost:3000',
+    apiKey: process.env.API_KEY!
+  });
+
+  const agent = await market.registerAgent('paying-agent', 'owner-1');
+
+  // Set up daily payment for server costs
+  await market.registerAutoPayment(agent.id, {
+    recipient_address: '0xInfraProvider...',
+    amount_usdc: 10.0,
+    interval_seconds: 86400,
+    description: 'Daily compute costs'
+  });
+
+  // Set up weekly payment for API access
+  await market.registerAutoPayment(agent.id, {
+    recipient_address: '0xApiProvider...',
+    amount_usdc: 25.0,
+    interval_seconds: 604800,
+    description: 'Weekly API subscription'
+  });
+
+  console.log('Auto-payments configured');
+}
+
+setupAutoPayments().catch(console.error);
+```


### PR DESCRIPTION
## Summary
- 商用リリースに向けた日英バイリンガルドキュメントの整備
- Webhook テスト追加とテスト基盤の修正

## Documentation (5 files, 3,000+ lines)

| ファイル | 内容 |
|---|---|
| **README.md** | 英語版 - アーキテクチャ図、API リファレンス、SDK 使用例、Quick Start |
| **README.ja.md** | 日本語版 - 自然な日本語で同等の内容をカバー |
| **docs/api.md** | 全 API エンドポイントの curl 例 + Mermaid シーケンス図 |
| **docs/sdk.md** | @openclaw/marketplace-sdk の使い方ガイド + TypeScript 例 |
| **docs/deployment.md** | 本番デプロイガイド、KMS 移行手順、セキュリティベストプラクティス |

## Test improvements
- `backend/tests/webhooks.test.ts` 新規追加 (9 テストケース)
- 全 6 テストファイルの `pool.end()` スコープバグ修正
- vitest に `fileParallelism: false` 追加（TRUNCATE デッドロック防止）
- **全 36 テスト合格**

## Test plan
- [ ] README.md / README.ja.md の言語切り替えリンクが動作すること
- [ ] docs/ 配下の各ドキュメントが正しくレンダリングされること
- [ ] `cd backend && npx vitest run` で全 36 テストが通ること

🤖 Generated with [Claude Code](https://claude.com/claude-code)