### PR TITLE
feat: add pagination and 24h listing retention with top 100 permanent

### DIFF
--- a/backend/package.json
+++ b/backend/package.json
@@ -8,6 +8,7 @@
     "build": "tsc -p tsconfig.json",
     "start": "node dist/index.js",
     "worker": "tsx src/worker.ts",
+    "retention": "tsx src/retention-worker.ts",
     "test": "vitest run",
     "migrate": "node-pg-migrate -c node-pg-migrate.json up",
     "migrate:down": "node-pg-migrate -c node-pg-migrate.json down"

--- a/backend/src/retention-worker.ts
+++ b/backend/src/retention-worker.ts
@@ -1,0 +1,32 @@
+import 'dotenv/config';
+import { runRetentionJob, getRetentionStats } from './services/listing-retention.js';
+import { logger } from './logger.js';
+
+const INTERVAL_MS = 60 * 60 * 1000; // Run every hour
+
+async function runJob() {
+  try {
+    const stats = await getRetentionStats();
+    logger.info({ stats }, 'Retention stats before job');
+
+    const result = await runRetentionJob();
+    logger.info({ result }, 'Retention job completed');
+  } catch (err) {
+    logger.error({ err }, 'Retention job failed');
+  }
+}
+
+async function main() {
+  logger.info('Starting retention worker');
+
+  // Run immediately on startup
+  await runJob();
+
+  // Then run every hour
+  setInterval(runJob, INTERVAL_MS);
+}
+
+main().catch((err) => {
+  logger.error({ err }, 'Retention worker crashed');
+  process.exit(1);
+});

--- a/backend/src/services/listing-retention.ts
+++ b/backend/src/services/listing-retention.ts
@@ -1,0 +1,91 @@
+import { pool } from '../db/index.js';
+import { logger } from '../logger.js';
+
+const RETENTION_HOURS = 24;
+const TOP_PERMANENT_COUNT = 100;
+
+/**
+ * Mark top 100 listings as permanent based on rating and review count.
+ * Only considers non-hidden listings with at least 1 review.
+ */
+export async function markTopListingsAsPermanent(): Promise<number> {
+  const result = await pool.query(`
+    WITH top_listings AS (
+      SELECT id
+      FROM listings
+      WHERE is_hidden = false AND review_count > 0
+      ORDER BY average_rating DESC, review_count DESC, created_at ASC
+      LIMIT $1
+    )
+    UPDATE listings
+    SET is_permanent = true
+    WHERE id IN (SELECT id FROM top_listings)
+      AND is_permanent = false
+    RETURNING id
+  `, [TOP_PERMANENT_COUNT]);
+
+  return result.rowCount ?? 0;
+}
+
+/**
+ * Remove non-permanent listings older than RETENTION_HOURS.
+ * Returns the number of deleted listings.
+ */
+export async function cleanupOldListings(): Promise<number> {
+  const cutoff = new Date(Date.now() - RETENTION_HOURS * 60 * 60 * 1000);
+
+  const result = await pool.query(`
+    DELETE FROM listings
+    WHERE is_permanent = false
+      AND created_at < $1
+    RETURNING id
+  `, [cutoff]);
+
+  return result.rowCount ?? 0;
+}
+
+/**
+ * Run the full retention job:
+ * 1. Mark top listings as permanent
+ * 2. Clean up old non-permanent listings
+ */
+export async function runRetentionJob(): Promise<{ marked: number; deleted: number }> {
+  logger.info('Starting listing retention job');
+
+  const marked = await markTopListingsAsPermanent();
+  logger.info({ marked }, 'Marked top listings as permanent');
+
+  const deleted = await cleanupOldListings();
+  logger.info({ deleted }, 'Deleted old non-permanent listings');
+
+  return { marked, deleted };
+}
+
+/**
+ * Get retention stats for monitoring
+ */
+export async function getRetentionStats(): Promise<{
+  total: number;
+  permanent: number;
+  temporary: number;
+  olderThan24h: number;
+}> {
+  const cutoff = new Date(Date.now() - RETENTION_HOURS * 60 * 60 * 1000);
+
+  const result = await pool.query(`
+    SELECT
+      COUNT(*) as total,
+      COUNT(*) FILTER (WHERE is_permanent = true) as permanent,
+      COUNT(*) FILTER (WHERE is_permanent = false) as temporary,
+      COUNT(*) FILTER (WHERE is_permanent = false AND created_at < $1) as older_than_24h
+    FROM listings
+  `, [cutoff]);
+
+  const row = result.rows[0];
+  return {
+    total: parseInt(row.total, 10),
+    permanent: parseInt(row.permanent, 10),
+    temporary: parseInt(row.temporary, 10),
+    olderThan24h: parseInt(row.older_than_24h, 10)
+  };
+}

--- a/migrations/003_listing_retention.cjs
+++ b/migrations/003_listing_retention.cjs
@@ -1,0 +1,43 @@
+/**
+ * @type {import('node-pg-migrate').ColumnDefinitions | undefined}
+ */
+exports.shorthands = undefined;
+
+/**
+ * @param pgm {import('node-pg-migrate').MigrationBuilder}
+ * @param run {() => void | undefined}
+ * @returns {Promise<void> | void}
+ */
+exports.up = (pgm) => {
+  // Add is_permanent column to mark top listings that should be kept forever
+  pgm.addColumn('listings', {
+    is_permanent: {
+      type: 'boolean',
+      default: false,
+      notNull: true
+    }
+  });
+
+  // Add index for cleanup queries
+  pgm.createIndex('listings', ['created_at', 'is_permanent'], {
+    name: 'listings_retention_index',
+    where: 'is_permanent = false'
+  });
+
+  // Add index for sorting by rating (for top 100)
+  pgm.createIndex('listings', ['average_rating', 'review_count'], {
+    name: 'listings_rating_index',
+    where: 'is_hidden = false'
+  });
+};
+
+/**
+ * @param pgm {import('node-pg-migrate').MigrationBuilder}
+ * @param run {() => void | undefined}
+ * @returns {Promise<void> | void}
+ */
+exports.down = (pgm) => {
+  pgm.dropIndex('listings', [], { name: 'listings_rating_index' });
+  pgm.dropIndex('listings', [], { name: 'listings_retention_index' });
+  pgm.dropColumn('listings', 'is_permanent');
+};

--- a/molt-market-retention.service
+++ b/molt-market-retention.service
@@ -1,0 +1,15 @@
+[Unit]
+Description=Molt Market Retention Worker
+After=network.target postgresql.service redis-server.service molt-market.service
+
+[Service]
+Type=simple
+User=exedev
+WorkingDirectory=/home/exedev/molt-market
+ExecStart=/usr/bin/npm run retention
+Restart=always
+RestartSec=30
+Environment=NODE_ENV=production
+
+[Install]
+WantedBy=multi-user.target

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
     "build": "npm --prefix backend run build",
     "start": "npm --prefix backend run start",
     "worker": "npm --prefix backend run worker",
+    "retention": "npm --prefix backend run retention",
     "migrate": "npm --prefix backend run migrate",
     "test": "npm --prefix backend run test"
   }


### PR DESCRIPTION
## Summary
データ肥大化防止のため、ページングと自動クリーンアップ機能を追加

## Changes

### Pagination
- 20件ずつページング表示
- Load More ボタンで追加読み込み
- 検索・ソート機能はそのまま維持

### Listing Retention (24時間ルール)
- `is_permanent` カラムを追加
- 24時間以上経過した非永続リスティングは自動削除
- **トップ100** (評価順) は永続化され削除されない
- 毎時間クリーンアップジョブが実行

### New Files
- `backend/src/services/listing-retention.ts` - 保持ロジック
- `backend/src/retention-worker.ts` - ワーカープロセス
- `migrations/003_listing_retention.cjs` - DBマイグレーション
- `molt-market-retention.service` - systemdサービス

## Deployment
```bash
npm run migrate
sudo systemctl enable molt-market-retention
sudo systemctl start molt-market-retention
```