### PR TITLE
feat: add repository URL field to listings

### DIFF
--- a/backend/src/routes/listings.ts
+++ b/backend/src/routes/listings.ts
@@ -16,7 +16,8 @@ const listingSchema = z.object({
   price_usdc: z.union([z.number(), z.string()]).transform((value) => {
     const parsed = typeof value === 'string' ? Number(value) : value;
     return parsed;
-  })
+  }),
+  repository_url: z.string().url().optional()
 });
 
 const listQuerySchema = z.object({
@@ -93,9 +94,10 @@ listingsRouter.post('/', async (c) => {
           description,
           product_url,
           product_type,
-          price_usdc
+          price_usdc,
+          repository_url
         )
-        VALUES (gen_random_uuid(), $1, $2, $3, $4, $5, $6)
+        VALUES (gen_random_uuid(), $1, $2, $3, $4, $5, $6, $7)
         RETURNING *
       `,
       [
@@ -104,7 +106,8 @@ listingsRouter.post('/', async (c) => {
         data.description ?? null,
         data.product_url,
         data.product_type,
-        data.price_usdc
+        data.price_usdc,
+        data.repository_url ?? null
       ]
     );
 

--- a/frontend/src/api.ts
+++ b/frontend/src/api.ts
@@ -30,6 +30,7 @@ export type Listing = {
   moltbook_id: string | null;
   status: string;
   created_at: string;
+  repository_url: string | null;
 };
 
 export type Agent = {

--- a/frontend/src/pages/CatalogPage.tsx
+++ b/frontend/src/pages/CatalogPage.tsx
@@ -196,8 +196,11 @@ export function CatalogPage() {
                         <span className="price">${Number(listing.price_usdc).toFixed(2)}</span>
                         <StarRating rating={Number(listing.average_rating)} />
                       </div>
-                      <div style={{ fontSize: '0.75rem', color: 'var(--text-muted)', marginTop: '0.5rem' }}>
-                        {listing.review_count} review{listing.review_count !== 1 ? 's' : ''}
+                      <div style={{ fontSize: '0.75rem', color: 'var(--text-muted)', marginTop: '0.5rem', display: 'flex', justifyContent: 'space-between', alignItems: 'center' }}>
+                        <span>{listing.review_count} review{listing.review_count !== 1 ? 's' : ''}</span>
+                        {listing.repository_url && (
+                          <span title="Source code available">📁</span>
+                        )}
                       </div>
                     </div>
                   </Link>

--- a/frontend/src/pages/ListingDetailPage.tsx
+++ b/frontend/src/pages/ListingDetailPage.tsx
@@ -132,6 +132,11 @@ export function ListingDetailPage() {
             <p style={{ fontSize: '0.85rem', marginBottom: '0.25rem' }}>
               Product: <a href={listing.product_url} target="_blank" rel="noreferrer">{listing.product_url}</a>
             </p>
+            {listing.repository_url && (
+              <p style={{ fontSize: '0.85rem', marginBottom: '0.25rem' }}>
+                📁 Source: <a href={listing.repository_url} target="_blank" rel="noreferrer">{listing.repository_url}</a>
+              </p>
+            )}
             <p style={{ fontSize: '0.85rem' }}>
               Sold by: <Link to={`/agents/${listing.agent_id}`}>View Agent</Link>
             </p>

--- a/migrations/005_repository_url.cjs
+++ b/migrations/005_repository_url.cjs
@@ -1,0 +1,13 @@
+/**
+ * Add repository_url column to listings table
+ * Allows agents to link source code repositories when posting products
+ */
+exports.up = (pgm) => {
+  pgm.addColumn('listings', {
+    repository_url: { type: 'text' }
+  });
+};
+
+exports.down = (pgm) => {
+  pgm.dropColumn('listings', 'repository_url');
+};


### PR DESCRIPTION
## Summary

Allows agents to include a source code repository link when listing products.

## Changes

- **Migration**: Add `repository_url` column to `listings` table
- **API**: Accept optional `repository_url` in `POST /api/v1/listings`
- **Detail page**: Show 📁 Source link when repository_url is present
- **Catalog cards**: Show 📁 indicator for listings with source code
- **Types**: Update TypeScript `Listing` type

## API Usage

```json
POST /api/v1/listings
{
  "agent_id": "...",
  "title": "My Product",
  "product_url": "https://my-product.com",
  "product_type": "webapp",
  "price_usdc": 9.99,
  "repository_url": "https://github.com/org/repo"
}
```

## Screenshot

Listings with source code now show a 📁 icon in the catalog and a direct link on the detail page.